### PR TITLE
Display visitor parameters in table

### DIFF
--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -185,6 +185,13 @@ func (p *Proxy) GetAlias() []string {
 	return []string{p.Name}
 }
 
+// IsVisitor returns a boolean indicating whether the proxy has a visitor role.
+func (p *Proxy) IsVisitor() bool {
+	return (p.Type == consts.ProxyTypeXTCP ||
+		p.Type == consts.ProxyTypeSTCP ||
+		p.Type == consts.ProxyTypeSUDP) && p.Role == "visitor"
+}
+
 // Marshal returns the encoded proxy
 func (p *Proxy) Marshal() ([]byte, error) {
 	cfg := ini.Empty()
@@ -299,7 +306,7 @@ func (conf *ClientConfig) Complete(read bool) {
 	}
 	// Proxies
 	for _, proxy := range conf.Proxies {
-		if funk.ContainsString([]string{consts.ProxyTypeXTCP, consts.ProxyTypeSTCP, consts.ProxyTypeSUDP}, proxy.Type) && proxy.Role == "visitor" {
+		if proxy.IsVisitor() {
 			var base = proxy.BaseProxyConf
 			// Visitor
 			if p, err := util.PruneByTag(*proxy, "true", "visitor"); err == nil {

--- a/pkg/consts/res.go
+++ b/pkg/consts/res.go
@@ -55,8 +55,9 @@ const (
 
 // Colors
 var (
-	ColorBlue = walk.RGB(11, 53, 137)
-	ColorGray = walk.RGB(109, 109, 109)
+	ColorBlue     = walk.RGB(0, 0, 255)
+	ColorDarkBlue = walk.RGB(11, 53, 137)
+	ColorGray     = walk.RGB(109, 109, 109)
 )
 
 // Text

--- a/ui/aboutpage.go
+++ b/ui/aboutpage.go
@@ -49,7 +49,7 @@ func (ap *AboutPage) Page() TabPage {
 					Composite{
 						Layout: VBox{Margins: Margins{12, 0, 0, 0}},
 						Children: []Widget{
-							Label{Text: "FRP Manager", Font: consts.TextLarge, TextColor: consts.ColorBlue},
+							Label{Text: "FRP Manager", Font: consts.TextLarge, TextColor: consts.ColorDarkBlue},
 							Label{Text: i18n.Sprintf("Version: %s", version.Number)},
 							Label{Text: i18n.Sprintf("FRP version: %s", version.FRPVersion)},
 							Label{Text: i18n.Sprintf("Built on: %s", version.BuildDate)},

--- a/ui/editproxy.go
+++ b/ui/editproxy.go
@@ -79,7 +79,7 @@ func NewEditProxyDialog(proxy *config.Proxy, exist bool) *EditProxyDialog {
 	v.Proxy = proxy
 	v.binder = &editProxyBinder{
 		Proxy:   *v.Proxy,
-		Visitor: proxy.Role == "visitor",
+		Visitor: proxy.IsVisitor(),
 	}
 	v.binder.BandwidthNum, v.binder.BandwidthUnit = splitBandwidth(v.Proxy.BandwidthLimit)
 	return v

--- a/ui/proxyview.go
+++ b/ui/proxyview.go
@@ -256,8 +256,8 @@ func (pv *ProxyView) createProxyTable() TableView {
 		Columns: []TableViewColumn{
 			{Title: i18n.Sprintf("Name"), DataMember: "Name", Width: 100},
 			{Title: i18n.Sprintf("Type"), DataMember: "Type", Width: 55},
-			{Title: i18n.Sprintf("Local Address"), DataMember: "LocalIP", Width: 110},
-			{Title: i18n.Sprintf("Local Port"), DataMember: "LocalPort", Width: 90},
+			{Title: i18n.Sprintf("Local Address"), DataMember: "DisplayLocalIP", Width: 110},
+			{Title: i18n.Sprintf("Local Port"), DataMember: "DisplayLocalPort", Width: 90},
 			{Title: i18n.Sprintf("Remote Port"), DataMember: "RemotePort", Width: 90},
 			{Title: i18n.Sprintf("Domains"), DataMember: "Domains", Width: 80},
 			{Title: i18n.Sprintf("Plugin"), DataMember: "Plugin", Width: 80},
@@ -310,8 +310,15 @@ func (pv *ProxyView) createProxyTable() TableView {
 			pv.onEdit(true, nil)
 		},
 		StyleCell: func(style *walk.CellStyle) {
-			if _, proxy := pv.getConfigProxy(style.Row()); proxy != nil && proxy.Disabled {
-				style.TextColor = consts.ColorGray
+			if _, proxy := pv.getConfigProxy(style.Row()); proxy != nil {
+				if proxy.Disabled {
+					// Disabled proxy
+					style.TextColor = consts.ColorGray
+				} else if proxy.IsVisitor() {
+					// Visitor proxy
+					style.TextColor = consts.ColorBlue
+				}
+				// Normal proxy is default black text
 			}
 		},
 	}


### PR DESCRIPTION
A proxy has visitor role will be displayed as **blue text**. Morever, we remap the following parameters to existing columns in table.

- bind_addr --> Local Address
- bind_port --> Local Port
- server_name --> Domains

It fills out many empty columns.

Fix #27.