### PR TITLE
Hot-Reloading proxy configuration

### DIFF
--- a/services/client.go
+++ b/services/client.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"time"
+
+	_ "github.com/fatedier/frp/assets/frpc"
+	"github.com/fatedier/frp/client"
+	"github.com/fatedier/frp/pkg/config"
+	"github.com/fatedier/frp/pkg/util/log"
+)
+
+type FrpClientService struct {
+	svr  *client.Service
+	file string
+}
+
+func NewFrpClientService(cfgFile string) (*FrpClientService, error) {
+	cfg, pxyCfgs, visitorCfgs, err := config.ParseClientConfig(cfgFile)
+	if err != nil {
+		return nil, err
+	}
+	svr, err := client.NewService(cfg, pxyCfgs, visitorCfgs, cfgFile)
+	if err != nil {
+		return nil, err
+	}
+	log.InitLog(cfg.LogWay, cfg.LogFile, cfg.LogLevel,
+		cfg.LogMaxDays, cfg.DisableLogColor)
+	return &FrpClientService{svr: svr, file: cfgFile}, nil
+}
+
+// Run starts frp client service in blocking mode.
+func (s *FrpClientService) Run() {
+	if s.file != "" {
+		log.Trace("start frpc service for config file [%s]", s.file)
+		defer log.Trace("frpc service for config file [%s] stopped", s.file)
+	}
+
+	// There's no guarantee that this function will return after a close call.
+	// So we can't wait for the Run function to finish.
+	if err := s.svr.Run(); err != nil {
+		log.Error("run service error: %v", err)
+	}
+}
+
+// Stop closes all frp connections.
+func (s *FrpClientService) Stop(wait bool) {
+	// Close client service.
+	if wait {
+		s.svr.GracefulClose(500 * time.Millisecond)
+	} else {
+		s.svr.Close()
+	}
+}
+
+// Reload creates or updates or removes proxies of frpc.
+func (s *FrpClientService) Reload() error {
+	_, pxyCfgs, visitorCfgs, err := config.ParseClientConfig(s.file)
+	if err != nil {
+		return err
+	}
+	return s.svr.ReloadConf(pxyCfgs, visitorCfgs)
+}

--- a/services/frp.go
+++ b/services/frp.go
@@ -6,17 +6,9 @@ import (
 	"github.com/koho/frpmgr/pkg/config"
 	"github.com/koho/frpmgr/pkg/util"
 
-	_ "github.com/fatedier/frp/assets/frpc"
-	frpc "github.com/fatedier/frp/cmd/frpc/sub"
 	frpconfig "github.com/fatedier/frp/pkg/config"
 	"github.com/fatedier/frp/pkg/util/log"
 )
-
-func runFrpClient() {
-	// Change program arguments for frpc to parse
-	// No need to change it for now
-	frpc.Execute()
-}
 
 func deleteFrpConfig(serviceName string, configPath string, c config.Config) {
 	// Delete logs

--- a/services/install.go
+++ b/services/install.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -41,14 +40,10 @@ func InstallService(name string, configPath string, manual bool) error {
 	serviceName := ServiceNameOfClient(name)
 	service, err := m.OpenService(serviceName)
 	if err == nil {
-		status, err := service.Query()
+		_, err = service.Query()
 		if err != nil && err != windows.ERROR_SERVICE_MARKED_FOR_DELETE {
 			service.Close()
 			return err
-		}
-		if status.State != svc.Stopped && err != windows.ERROR_SERVICE_MARKED_FOR_DELETE {
-			service.Close()
-			return errors.New("service already installed and running")
 		}
 		err = service.Delete()
 		service.Close()

--- a/services/service.go
+++ b/services/service.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/koho/frpmgr/pkg/config"
 	"github.com/koho/frpmgr/pkg/util"
 
+	"github.com/fatedier/frp/pkg/util/log"
 	"golang.org/x/sys/windows/svc"
 )
 
@@ -37,7 +37,6 @@ func (service *frpService) Execute(args []string, r <-chan svc.ChangeRequest, ch
 
 	defer func() {
 		changes <- svc.Status{State: svc.StopPending}
-		log.Println("Shutting down")
 	}()
 
 	cc, err := config.UnmarshalClientConfFromIni(service.configPath)
@@ -59,31 +58,60 @@ func (service *frpService) Execute(args []string, r <-chan svc.ChangeRequest, ch
 		return
 	}
 
-	go runFrpClient()
+	svr, err := NewFrpClientService(service.configPath)
+	if err != nil {
+		return
+	}
 
-	changes <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
-	log.Println("Startup complete")
+	go svr.Run()
+
+	changes <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown | svc.AcceptParamChange}
 
 	for {
 		select {
 		case c := <-r:
 			switch c.Cmd {
 			case svc.Stop, svc.Shutdown:
+				svr.Stop(false)
 				return
+			case svc.ParamChange:
+				// Reload service
+				if err = svr.Reload(); err != nil {
+					log.Warn("reload frp config error: %s", err.Error())
+				}
 			case svc.Interrogate:
 				changes <- c.CurrentStatus
 			default:
-				log.Printf("Unexpected services control request #%d\n", c)
 			}
 		case <-expired:
+			svr.Stop(false)
 			deleteFrpConfig(args[0], service.configPath, cc)
 			return
 		}
 	}
 }
 
+// Run executes frp service in background service process.
 func Run(configPath string) error {
 	baseName, _ := util.SplitExt(configPath)
 	serviceName := ServiceNameOfClient(baseName)
 	return svc.Run(serviceName, &frpService{configPath})
+}
+
+// ReloadService sends a reload event to the frp service
+// which triggers hot-reloading of frp configuration.
+func ReloadService(confName string) error {
+	m, err := serviceManager()
+	if err != nil {
+		return err
+	}
+
+	svcName := ServiceNameOfClient(confName)
+	service, err := m.OpenService(svcName)
+	if err != nil {
+		return err
+	}
+	defer service.Close()
+	_, err = service.Control(svc.ParamChange)
+	return err
 }

--- a/ui/conf.go
+++ b/ui/conf.go
@@ -14,6 +14,15 @@ import (
 	"github.com/thoas/go-funk"
 )
 
+// The flag controls the running state of service.
+type runFlag int
+
+const (
+	runFlagAuto runFlag = iota
+	runFlagForceStart
+	runFlagReload
+)
+
 // Conf contains all data of a config
 type Conf struct {
 	sync.Mutex
@@ -145,7 +154,7 @@ type ConfBinder struct {
 	// Selected indicates whether there's a selected config
 	Selected bool
 	// Commit will save the given config and try to reload service
-	Commit func(conf *Conf, forceStart bool)
+	Commit func(conf *Conf, flag runFlag)
 }
 
 // getCurrentConf returns the current selected config
@@ -170,10 +179,10 @@ func setCurrentConf(conf *Conf) {
 }
 
 // commitConf will save the given config and try to reload service
-func commitConf(conf *Conf, forceStart bool) {
+func commitConf(conf *Conf, flag runFlag) {
 	if confDB != nil {
 		if ds, ok := confDB.DataSource().(*ConfBinder); ok {
-			ds.Commit(conf, forceStart)
+			ds.Commit(conf, flag)
 		}
 	}
 }

--- a/ui/confview.go
+++ b/ui/confview.go
@@ -253,7 +253,11 @@ func (cv *ConfView) onEditConf(conf *Conf, name string) {
 			confDB.Reset()
 		}
 		// Commit the config
-		commitConf(dlg.Conf, dlg.ShouldRestart)
+		flag := runFlagAuto
+		if dlg.ShouldRestart {
+			flag = runFlagForceStart
+		}
+		commitConf(dlg.Conf, flag)
 	}
 }
 

--- a/ui/proxyview.go
+++ b/ui/proxyview.go
@@ -514,7 +514,7 @@ func (pv *ProxyView) switchToggleAction() {
 func (pv *ProxyView) commit() {
 	pv.Invalidate()
 	if pv.model != nil {
-		commitConf(pv.model.conf, false)
+		commitConf(pv.model.conf, runFlagReload)
 	}
 }
 


### PR DESCRIPTION
The hot reloading feature allows you to inject newly edited proxies at runtime without stopping the service.

**Note that hot reloading common settings of a config is not supported.**