### PR TITLE
Add NAT discovery tool

### DIFF
--- a/i18n/catalog.go
+++ b/i18n/catalog.go
@@ -43,240 +43,250 @@ func init() {
 }
 
 var messageKeyToIndex = map[string]int{
-	"* Leave blank to record no log and delete the original log file.": 69,
-	"* Refer to the [common] section of the FRP configuration file.":   116,
-	"* Refer to the parameters supported by FRP.":                      162,
-	"* Support batch import, one link per line.":                       215,
-	"A selection is required.":                                         230,
+	"* Leave blank to record no log and delete the original log file.": 71,
+	"* Refer to the [common] section of the FRP configuration file.":   118,
+	"* Refer to the parameters supported by FRP.":                      164,
+	"* Support batch import, one link per line.":                       225,
+	"A selection is required.":                                         240,
 	"About":                                                            15,
-	"Absolute":                                                         81,
-	"Add":                                                              179,
-	"Admin":                                                            74,
-	"Admin Address":                                                    75,
-	"Admin Port":                                                       76,
-	"Advanced":                                                         107,
+	"Absolute":                                                         83,
+	"Add":                                                              189,
+	"Admin":                                                            76,
+	"Admin Address":                                                    77,
+	"Admin Port":                                                       78,
+	"Advanced":                                                         109,
 	"All":                                                              34,
 	"All Files":                                                        3,
 	"An error occurred while checking for a software update.": 21,
-	"Another config already exists with the name \"%s\".":     46,
-	"Are you sure you would like to delete config \"%s\"?":    49,
-	"Are you sure you would like to delete proxy \"%s\"?":     209,
-	"Are you sure you would like to disable proxy \"%s\"?":    211,
-	"Assets":                 78,
-	"Audience":               62,
-	"Auth":                   57,
-	"Auth Method":            58,
-	"Authentication":         65,
-	"Auto Delete":            80,
-	"Bandwidth":              139,
-	"Basic":                  52,
-	"Bind Address":           129,
-	"Bind Port":              130,
+	"Another config already exists with the name \"%s\".":     47,
+	"Are you sure you would like to delete config \"%s\"?":    50,
+	"Are you sure you would like to delete proxy \"%s\"?":     219,
+	"Are you sure you would like to disable proxy \"%s\"?":    221,
+	"Assets":                 80,
+	"Audience":               64,
+	"Auth":                   59,
+	"Auth Method":            60,
+	"Authentication":         67,
+	"Auto Delete":            82,
+	"Bandwidth":              141,
+	"Basic":                  53,
+	"Behavior":               172,
+	"Bind Address":           131,
+	"Bind Port":              132,
 	"Built on: %s":           2,
 	"Cancel":                 24,
-	"Certificate":            101,
+	"Certificate":            103,
 	"Certificate Files":      5,
-	"Certificate Key":        103,
-	"Change Password":        186,
-	"Check Interval":         161,
-	"Check Timeout":          159,
-	"Check Type":             158,
+	"Certificate Key":        105,
+	"Change Password":        196,
+	"Check Interval":         163,
+	"Check Timeout":          161,
+	"Check Type":             160,
 	"Check for updates":      18,
 	"Checking for updates":   17,
-	"Client":                 137,
+	"Client":                 139,
 	"Common Only":            35,
-	"Compression":            143,
-	"Config already exists":  117,
+	"Compression":            145,
+	"Config already exists":  119,
 	"Config already removed": 28,
 	"Configuration":          25,
 	"Configuration Files":    4,
-	"Connection":             86,
-	"Copy":                   174,
-	"Copy Access Address":    207,
-	"Copy Share Link":        39,
+	"Connection":             88,
+	"Copy":                   184,
+	"Copy Access Address":    217,
+	"Copy Share Link":        41,
 	"Create a Copy":          33,
-	"Custom":                 114,
-	"Custom Domains":         133,
-	"Custom Options":         115,
-	"Days":                   85,
-	"Defaults":               191,
-	"Define the default value when creating a new configuration.\nThe value here will not affect the existing configuration.": 192,
-	"Delete":                        41,
-	"Delete Date":                   83,
-	"Delete Days":                   84,
-	"Delete config \"%s\"":          48,
-	"Delete proxy \"%s\"":           208,
-	"Dial Timeout":                  94,
-	"Direct Edit":                   205,
-	"Disable":                       212,
-	"Disable auto-start at boot":    113,
-	"Disable proxy \"%s\"":          210,
-	"Domains":                       206,
-	"Download":                      219,
+	"Custom":                 116,
+	"Custom Domains":         135,
+	"Custom Options":         117,
+	"Days":                   87,
+	"Defaults":               201,
+	"Define the default value when creating a new configuration.\nThe value here will not affect the existing configuration.": 202,
+	"Delete":                        43,
+	"Delete Date":                   85,
+	"Delete Days":                   86,
+	"Delete config \"%s\"":          49,
+	"Delete proxy \"%s\"":           218,
+	"Dial Timeout":                  96,
+	"Direct Edit":                   215,
+	"Disable":                       222,
+	"Disable auto-start at boot":    115,
+	"Disable proxy \"%s\"":          220,
+	"Domains":                       216,
+	"Download":                      229,
 	"Download updates":              16,
 	"Edit":                          30,
-	"Edit Client - %s":              51,
-	"Edit Proxy - %s":               120,
-	"Empty":                         141,
-	"Enable":                        203,
-	"Encryption":                    142,
-	"Enter Administration Password": 222,
-	"Enter Password":                220,
-	"Exit after login failure":      112,
-	"Export All Configs to ZIP":     40,
-	"FRP Manager":                   214,
+	"Edit Client - %s":              52,
+	"Edit Proxy - %s":               122,
+	"Empty":                         143,
+	"Enable":                        213,
+	"Encryption":                    144,
+	"Enter Administration Password": 232,
+	"Enter Password":                230,
+	"Exit after login failure":      114,
+	"Export All Configs to ZIP":     42,
+	"External Address":              173,
+	"FRP Manager":                   224,
 	"FRP version: %s":               1,
-	"Failure Count":                 160,
+	"Failure Count":                 162,
 	"For FRP configuration documentation, please visit the FRP project page:": 20,
 	"For comments or to report bugs, please visit the project page:":          19,
-	"Group":                                  155,
-	"Group Key":                              156,
-	"HTTP File Server":                       202,
-	"HTTP Password":                          145,
-	"HTTP Proxy":                             88,
-	"HTTP User":                              144,
-	"Health Check":                           157,
-	"Heart Beats":                            66,
-	"Heartbeat":                              90,
-	"Host Name":                              100,
-	"Host Rewrite":                           146,
-	"Idle Timeout":                           96,
-	"Import Config":                          44,
+	"Group":                                  157,
+	"Group Key":                              158,
+	"HTTP File Server":                       212,
+	"HTTP Password":                          147,
+	"HTTP Proxy":                             90,
+	"HTTP User":                              146,
+	"Health Check":                           159,
+	"Heart Beats":                            68,
+	"Heartbeat":                              92,
+	"Host Name":                              102,
+	"Host Rewrite":                           148,
+	"Idle Timeout":                           98,
+	"Import Config":                          36,
 	"Import Config from File":                27,
-	"Import from Clipboard":                  38,
-	"Import from File":                       36,
-	"Import from URL":                        37,
-	"Imported %d of %d configs.":             45,
-	"Interval":                               91,
-	"Invalid Input":                          224,
-	"Keepalive":                              95,
+	"Import from Clipboard":                  39,
+	"Import from File":                       37,
+	"Import from URL":                        38,
+	"Imported %d of %d configs.":             46,
+	"Interval":                               93,
+	"Invalid Input":                          234,
+	"Item":                                   169,
+	"Keepalive":                              97,
 	"Key Files":                              6,
-	"Languages":                              187,
-	"Latest":                                 166,
-	"Level":                                  72,
-	"Load Balance":                           154,
-	"Local Address":                          126,
-	"Local Directory":                        178,
-	"Local Path":                             151,
-	"Local Port":                             127,
-	"Locations":                              134,
-	"Log":                                    68,
-	"Log File":                               70,
+	"Languages":                              197,
+	"Latest":                                 168,
+	"Level":                                  74,
+	"Load Balance":                           156,
+	"Local Address":                          128,
+	"Local Directory":                        188,
+	"Local Path":                             153,
+	"Local Port":                             129,
+	"Locations":                              136,
+	"Log":                                    70,
+	"Log File":                               72,
 	"Log Files":                              7,
-	"Log Level":                              198,
-	"Log retention":                          199,
-	"Manual Settings":                        43,
-	"Master password":                        183,
-	"Max Days":                               73,
-	"Max Streams":                            97,
-	"Multiplexer":                            135,
-	"Mux Keepalive":                          109,
-	"Name":                                   53,
-	"New Client":                             50,
-	"New Config":                             42,
+	"Log Level":                              208,
+	"Log retention":                          209,
+	"Manual Settings":                        45,
+	"Master password":                        193,
+	"Max Days":                               75,
+	"Max Streams":                            99,
+	"Multiplexer":                            137,
+	"Mux Keepalive":                          111,
+	"NAT Discovery":                          40,
+	"NAT Type":                               171,
+	"Name":                                   54,
+	"New Client":                             51,
+	"New Config":                             44,
 	"New Configuration":                      26,
-	"New Proxy":                              119,
+	"New Proxy":                              121,
 	"New Version!":                           14,
-	"New master password":                    195,
-	"None":                                   59,
+	"New master password":                    205,
+	"No":                                     175,
+	"None":                                   61,
 	"Not a number":                           12,
 	"Number out of allowed range":            8,
 	"OK":                                     23,
-	"Off":                                    99,
-	"On":                                     98,
-	"Open Config":                            204,
+	"Off":                                    101,
+	"On":                                     100,
+	"Open Config":                            214,
 	"Open File":                              31,
-	"Open Log Folder":                        165,
-	"Open Port":                              181,
-	"Other Options":                          111,
-	"Passive Port Range":                     213,
-	"Password":                               77,
-	"Password is set.":                       197,
+	"Open Log Folder":                        167,
+	"Open Port":                              191,
+	"Other Options":                          113,
+	"Passive Port Range":                     223,
+	"Password":                               79,
+	"Password is set.":                       207,
 	"Password mismatch":                      10,
-	"Password removed.":                      194,
+	"Password removed.":                      204,
 	"Please check and try again.":            11,
-	"Please enter a number from %.f to %.f.": 225,
-	"Please enter a number from %s to %s.":   226,
+	"Please enter a number from %.f to %.f.": 235,
+	"Please enter a number from %s to %s.":   236,
 	"Please enter a number greater than %d.": 9,
 	"Please enter a valid number.":           13,
-	"Please enter the correct URL list.":     218,
-	"Please select one of the provided options.": 229,
-	"Plugin":                                 147,
-	"Plugin Name":                            148,
-	"Pool Count":                             89,
-	"Port":                                   180,
-	"Preferences":                            182,
-	"Protocol":                               87,
-	"Proxy Version":                          140,
-	"Proxy already exists":                   163,
-	"Quick Add":                              200,
-	"Random":                                 121,
-	"Re-enter password":                      196,
-	"Ready":                                  217,
-	"Relative":                               82,
-	"Remote Address":                         173,
-	"Remote Desktop":                         201,
-	"Remote Port":                            128,
-	"Rename automatically":                   216,
-	"Role":                                   123,
-	"Route User":                             136,
-	"Running":                                168,
-	"Scope":                                  63,
-	"Secret":                                 61,
-	"Secret Key":                             125,
-	"Select Certificate File":                102,
-	"Select Certificate Key File":            104,
-	"Select Log File":                        71,
-	"Select Trusted CA File":                 106,
-	"Select Unix Path":                       150,
-	"Select a folder for directory listing.": 152,
-	"Select a local directory that the admin server will load resources from.": 79,
-	"Select language":                        190,
-	"Selection Required":                     228,
-	"Server":                                 138,
-	"Server Address":                         54,
-	"Server Name":                            131,
-	"Server Port":                            55,
-	"Service":                                176,
-	"Set Defaults":                           193,
+	"Please enter the correct URL list.":     228,
+	"Please select one of the provided options.": 239,
+	"Plugin":                                 149,
+	"Plugin Name":                            150,
+	"Pool Count":                             91,
+	"Port":                                   190,
+	"Preferences":                            192,
+	"Protocol":                               89,
+	"Proxy Version":                          142,
+	"Proxy already exists":                   165,
+	"Public Network":                         176,
+	"Quick Add":                              210,
+	"Random":                                 123,
+	"Re-enter password":                      206,
+	"Ready":                                  227,
+	"Relative":                               84,
+	"Remote Address":                         183,
+	"Remote Desktop":                         211,
+	"Remote Port":                            130,
+	"Rename automatically":                   226,
+	"Role":                                   125,
+	"Route User":                             138,
+	"Running":                                178,
+	"STUN Server":                            58,
+	"Scope":                                  65,
+	"Secret":                                 63,
+	"Secret Key":                             127,
+	"Select Certificate File":                104,
+	"Select Certificate Key File":            106,
+	"Select Log File":                        73,
+	"Select Trusted CA File":                 108,
+	"Select Unix Path":                       152,
+	"Select a folder for directory listing.": 154,
+	"Select a local directory that the admin server will load resources from.": 81,
+	"Select language":                        200,
+	"Selection Required":                     238,
+	"Server":                                 140,
+	"Server Address":                         55,
+	"Server Name":                            133,
+	"Server Port":                            56,
+	"Service":                                186,
+	"Set Defaults":                           203,
 	"Show in Folder":                         32,
-	"Source Address":                         110,
-	"Start":                                  175,
-	"Starting":                               170,
-	"Status":                                 172,
-	"Stop":                                   177,
-	"Stopped":                                169,
-	"Stopping":                               171,
-	"Strip Prefix":                           153,
-	"Subdomain":                              132,
-	"TCP Mux":                                108,
+	"Source Address":                         112,
+	"Start":                                  185,
+	"Starting":                               180,
+	"Status":                                 182,
+	"Stop":                                   187,
+	"Stopped":                                179,
+	"Stopping":                               181,
+	"Strip Prefix":                           155,
+	"Subdomain":                              134,
+	"TCP Mux":                                110,
 	"The config \"%s\" already removed.":     29,
-	"The config name \"%s\" already exists.": 118,
-	"The current display language is":        188,
-	"The file \"%s\" is not a valid ZIP file.":      47,
-	"The password is incorrect. Re-enter password.": 223,
-	"The proxy name \"%s\" already exists.":         164,
-	"The text does not match the required pattern.": 227,
+	"The config name \"%s\" already exists.": 120,
+	"The current display language is":        198,
+	"The file \"%s\" is not a valid ZIP file.":      48,
+	"The password is incorrect. Re-enter password.": 233,
+	"The proxy name \"%s\" already exists.":         166,
+	"The text does not match the required pattern.": 237,
 	"There are currently no updates available.":     22,
-	"Timeout":             93,
-	"Token":               60,
-	"Token Endpoint":      64,
-	"Trusted CA":          105,
-	"Type":                122,
-	"Unix Path":           149,
-	"Unknown":             167,
-	"Use master password": 185,
-	"User":                56,
+	"Timeout":             95,
+	"Token":               62,
+	"Token Endpoint":      66,
+	"Trusted CA":          107,
+	"Type":                124,
+	"Unix Path":           151,
+	"Unknown":             177,
+	"Use master password": 195,
+	"User":                57,
+	"Value":               170,
 	"Version: %s":         0,
-	"Visitor":             124,
-	"Work Conns":          67,
-	"You can set a password to restrict access to this program.\nYou will be asked to enter it the next time you use this program.": 184,
-	"You must enter an administration password to operate the %s.":                                                                  221,
-	"You must restart program to apply the modification.":                                                                           189,
-	"s": 92,
+	"Visitor":             126,
+	"Work Conns":          69,
+	"Yes":                 174,
+	"You can set a password to restrict access to this program.\nYou will be asked to enter it the next time you use this program.": 194,
+	"You must enter an administration password to operate the %s.":                                                                  231,
+	"You must restart program to apply the modification.":                                                                           199,
+	"s": 94,
 }
 
-var en_USIndex = []uint32{ // 232 elements
+var en_USIndex = []uint32{ // 242 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000f, 0x00000022, 0x00000032,
 	0x0000003c, 0x00000050, 0x00000062, 0x0000006c,
@@ -288,64 +298,67 @@ var en_USIndex = []uint32{ // 232 elements
 	0x0000028a, 0x000002a1, 0x000002c5, 0x000002ca,
 	// Entry 20 - 3F
 	0x000002d4, 0x000002e3, 0x000002f1, 0x000002f5,
-	0x00000301, 0x00000312, 0x00000322, 0x00000338,
-	0x00000348, 0x00000362, 0x00000369, 0x00000374,
-	0x00000384, 0x00000392, 0x000003b3, 0x000003e8,
-	0x00000412, 0x00000428, 0x0000045e, 0x00000469,
-	0x0000047d, 0x00000483, 0x00000488, 0x00000497,
-	0x000004a3, 0x000004a8, 0x000004ad, 0x000004b9,
-	0x000004be, 0x000004c4, 0x000004cb, 0x000004d4,
+	0x00000301, 0x0000030f, 0x00000320, 0x00000330,
+	0x00000346, 0x00000354, 0x00000364, 0x0000037e,
+	0x00000385, 0x00000390, 0x000003a0, 0x000003c1,
+	0x000003f6, 0x00000420, 0x00000436, 0x0000046c,
+	0x00000477, 0x0000048b, 0x00000491, 0x00000496,
+	0x000004a5, 0x000004b1, 0x000004b6, 0x000004c2,
+	0x000004c7, 0x000004d3, 0x000004d8, 0x000004de,
 	// Entry 40 - 5F
-	0x000004da, 0x000004e9, 0x000004f8, 0x00000504,
-	0x0000050f, 0x00000513, 0x00000554, 0x0000055d,
-	0x0000056d, 0x00000573, 0x0000057c, 0x00000582,
-	0x00000590, 0x0000059b, 0x000005a4, 0x000005ab,
-	0x000005f4, 0x00000600, 0x00000609, 0x00000612,
-	0x0000061e, 0x0000062a, 0x0000062f, 0x0000063a,
-	0x00000643, 0x0000064e, 0x00000659, 0x00000663,
-	0x0000066c, 0x0000066e, 0x00000676, 0x00000683,
+	0x000004e5, 0x000004ee, 0x000004f4, 0x00000503,
+	0x00000512, 0x0000051e, 0x00000529, 0x0000052d,
+	0x0000056e, 0x00000577, 0x00000587, 0x0000058d,
+	0x00000596, 0x0000059c, 0x000005aa, 0x000005b5,
+	0x000005be, 0x000005c5, 0x0000060e, 0x0000061a,
+	0x00000623, 0x0000062c, 0x00000638, 0x00000644,
+	0x00000649, 0x00000654, 0x0000065d, 0x00000668,
+	0x00000673, 0x0000067d, 0x00000686, 0x00000688,
 	// Entry 60 - 7F
-	0x0000068d, 0x0000069a, 0x000006a6, 0x000006a9,
-	0x000006ad, 0x000006b7, 0x000006c3, 0x000006db,
-	0x000006eb, 0x00000707, 0x00000712, 0x00000729,
-	0x00000732, 0x0000073a, 0x00000748, 0x00000757,
-	0x00000765, 0x0000077e, 0x00000799, 0x000007a0,
-	0x000007af, 0x000007ee, 0x00000804, 0x0000082c,
-	0x00000836, 0x00000849, 0x00000850, 0x00000855,
-	0x0000085a, 0x00000862, 0x0000086d, 0x0000087b,
+	0x00000690, 0x0000069d, 0x000006a7, 0x000006b4,
+	0x000006c0, 0x000006c3, 0x000006c7, 0x000006d1,
+	0x000006dd, 0x000006f5, 0x00000705, 0x00000721,
+	0x0000072c, 0x00000743, 0x0000074c, 0x00000754,
+	0x00000762, 0x00000771, 0x0000077f, 0x00000798,
+	0x000007b3, 0x000007ba, 0x000007c9, 0x00000808,
+	0x0000081e, 0x00000846, 0x00000850, 0x00000863,
+	0x0000086a, 0x0000086f, 0x00000874, 0x0000087c,
 	// Entry 80 - 9F
-	0x00000886, 0x00000892, 0x0000089f, 0x000008a9,
-	0x000008b5, 0x000008bf, 0x000008ce, 0x000008d8,
-	0x000008e4, 0x000008ef, 0x000008f6, 0x000008fd,
-	0x00000907, 0x00000915, 0x0000091b, 0x00000926,
-	0x00000932, 0x0000093c, 0x0000094a, 0x00000957,
-	0x0000095e, 0x0000096a, 0x00000974, 0x00000985,
-	0x00000990, 0x000009b7, 0x000009c4, 0x000009d1,
-	0x000009d7, 0x000009e1, 0x000009ee, 0x000009f9,
+	0x00000887, 0x00000895, 0x000008a0, 0x000008ac,
+	0x000008b9, 0x000008c3, 0x000008cf, 0x000008d9,
+	0x000008e8, 0x000008f2, 0x000008fe, 0x00000909,
+	0x00000910, 0x00000917, 0x00000921, 0x0000092f,
+	0x00000935, 0x00000940, 0x0000094c, 0x00000956,
+	0x00000964, 0x00000971, 0x00000978, 0x00000984,
+	0x0000098e, 0x0000099f, 0x000009aa, 0x000009d1,
+	0x000009de, 0x000009eb, 0x000009f1, 0x000009fb,
 	// Entry A0 - BF
-	0x00000a07, 0x00000a15, 0x00000a24, 0x00000a50,
-	0x00000a65, 0x00000a8c, 0x00000a9c, 0x00000aa3,
-	0x00000aab, 0x00000ab3, 0x00000abb, 0x00000ac4,
-	0x00000acd, 0x00000ad4, 0x00000ae3, 0x00000ae8,
-	0x00000aee, 0x00000af6, 0x00000afb, 0x00000b0b,
-	0x00000b0f, 0x00000b14, 0x00000b1e, 0x00000b2a,
-	0x00000b3a, 0x00000bb7, 0x00000bcb, 0x00000bdb,
-	0x00000be5, 0x00000c05, 0x00000c39, 0x00000c49,
+	0x00000a08, 0x00000a13, 0x00000a21, 0x00000a2f,
+	0x00000a3e, 0x00000a6a, 0x00000a7f, 0x00000aa6,
+	0x00000ab6, 0x00000abd, 0x00000ac2, 0x00000ac8,
+	0x00000ad1, 0x00000ada, 0x00000aeb, 0x00000aef,
+	0x00000af2, 0x00000b01, 0x00000b09, 0x00000b11,
+	0x00000b19, 0x00000b22, 0x00000b2b, 0x00000b32,
+	0x00000b41, 0x00000b46, 0x00000b4c, 0x00000b54,
+	0x00000b59, 0x00000b69, 0x00000b6d, 0x00000b72,
 	// Entry C0 - DF
-	0x00000c52, 0x00000cc9, 0x00000cd6, 0x00000ce8,
-	0x00000cfc, 0x00000d0e, 0x00000d1f, 0x00000d29,
-	0x00000d37, 0x00000d41, 0x00000d50, 0x00000d61,
-	0x00000d68, 0x00000d74, 0x00000d80, 0x00000d88,
-	0x00000d9c, 0x00000db1, 0x00000de6, 0x00000dfc,
-	0x00000e32, 0x00000e3a, 0x00000e4d, 0x00000e59,
-	0x00000e84, 0x00000e99, 0x00000e9f, 0x00000ec2,
-	0x00000ecb, 0x00000eda, 0x00000f1a, 0x00000f38,
+	0x00000b7c, 0x00000b88, 0x00000b98, 0x00000c15,
+	0x00000c29, 0x00000c39, 0x00000c43, 0x00000c63,
+	0x00000c97, 0x00000ca7, 0x00000cb0, 0x00000d27,
+	0x00000d34, 0x00000d46, 0x00000d5a, 0x00000d6c,
+	0x00000d7d, 0x00000d87, 0x00000d95, 0x00000d9f,
+	0x00000dae, 0x00000dbf, 0x00000dc6, 0x00000dd2,
+	0x00000dde, 0x00000de6, 0x00000dfa, 0x00000e0f,
+	0x00000e44, 0x00000e5a, 0x00000e90, 0x00000e98,
 	// Entry E0 - FF
-	0x00000f66, 0x00000f74, 0x00000fa1, 0x00000fcc,
-	0x00000ffa, 0x0000100d, 0x00001038, 0x00001051,
-} // Size: 952 bytes
+	0x00000eab, 0x00000eb7, 0x00000ee2, 0x00000ef7,
+	0x00000efd, 0x00000f20, 0x00000f29, 0x00000f38,
+	0x00000f78, 0x00000f96, 0x00000fc4, 0x00000fd2,
+	0x00000fff, 0x0000102a, 0x00001058, 0x0000106b,
+	0x00001096, 0x000010af,
+} // Size: 992 bytes
 
-const en_USData string = "" + // Size: 4177 bytes
+const en_USData string = "" + // Size: 4271 bytes
 	"\x02Version: %[1]s\x02FRP version: %[1]s\x02Built on: %[1]s\x02All Files" +
 	"\x02Configuration Files\x02Certificate Files\x02Key Files\x02Log Files" +
 	"\x02Number out of allowed range\x02Please enter a number greater than %[" +
@@ -358,65 +371,67 @@ const en_USData string = "" + // Size: 4177 bytes
 	"ilable.\x02OK\x02Cancel\x02Configuration\x02New Configuration\x02Import " +
 	"Config from File\x02Config already removed\x02The config \x22%[1]s\x22 a" +
 	"lready removed.\x02Edit\x02Open File\x02Show in Folder\x02Create a Copy" +
-	"\x02All\x02Common Only\x02Import from File\x02Import from URL\x02Import " +
-	"from Clipboard\x02Copy Share Link\x02Export All Configs to ZIP\x02Delete" +
-	"\x02New Config\x02Manual Settings\x02Import Config\x02Imported %[1]d of " +
-	"%[2]d configs.\x02Another config already exists with the name \x22%[1]s" +
-	"\x22.\x02The file \x22%[1]s\x22 is not a valid ZIP file.\x02Delete confi" +
-	"g \x22%[1]s\x22\x02Are you sure you would like to delete config \x22%[1]" +
-	"s\x22?\x02New Client\x02Edit Client - %[1]s\x02Basic\x02Name\x02Server A" +
-	"ddress\x02Server Port\x02User\x02Auth\x02Auth Method\x02None\x02Token" +
-	"\x02Secret\x02Audience\x02Scope\x02Token Endpoint\x02Authentication\x02H" +
-	"eart Beats\x02Work Conns\x02Log\x02* Leave blank to record no log and de" +
-	"lete the original log file.\x02Log File\x02Select Log File\x02Level\x02M" +
-	"ax Days\x02Admin\x02Admin Address\x02Admin Port\x02Password\x02Assets" +
-	"\x02Select a local directory that the admin server will load resources f" +
-	"rom.\x02Auto Delete\x02Absolute\x02Relative\x02Delete Date\x02Delete Day" +
-	"s\x02Days\x02Connection\x02Protocol\x02HTTP Proxy\x02Pool Count\x02Heart" +
-	"beat\x02Interval\x02s\x02Timeout\x02Dial Timeout\x02Keepalive\x02Idle Ti" +
-	"meout\x02Max Streams\x02On\x02Off\x02Host Name\x02Certificate\x02Select " +
-	"Certificate File\x02Certificate Key\x02Select Certificate Key File\x02Tr" +
-	"usted CA\x02Select Trusted CA File\x02Advanced\x02TCP Mux\x02Mux Keepali" +
-	"ve\x02Source Address\x02Other Options\x02Exit after login failure\x02Dis" +
-	"able auto-start at boot\x02Custom\x02Custom Options\x02* Refer to the [c" +
-	"ommon] section of the FRP configuration file.\x02Config already exists" +
-	"\x02The config name \x22%[1]s\x22 already exists.\x02New Proxy\x02Edit P" +
-	"roxy - %[1]s\x02Random\x02Type\x02Role\x02Visitor\x02Secret Key\x02Local" +
-	" Address\x02Local Port\x02Remote Port\x02Bind Address\x02Bind Port\x02Se" +
-	"rver Name\x02Subdomain\x02Custom Domains\x02Locations\x02Multiplexer\x02" +
-	"Route User\x02Client\x02Server\x02Bandwidth\x02Proxy Version\x02Empty" +
-	"\x02Encryption\x02Compression\x02HTTP User\x02HTTP Password\x02Host Rewr" +
-	"ite\x02Plugin\x02Plugin Name\x02Unix Path\x02Select Unix Path\x02Local P" +
-	"ath\x02Select a folder for directory listing.\x02Strip Prefix\x02Load Ba" +
-	"lance\x02Group\x02Group Key\x02Health Check\x02Check Type\x02Check Timeo" +
-	"ut\x02Failure Count\x02Check Interval\x02* Refer to the parameters suppo" +
-	"rted by FRP.\x02Proxy already exists\x02The proxy name \x22%[1]s\x22 alr" +
-	"eady exists.\x02Open Log Folder\x02Latest\x02Unknown\x02Running\x02Stopp" +
-	"ed\x02Starting\x02Stopping\x02Status\x02Remote Address\x02Copy\x02Start" +
-	"\x02Service\x02Stop\x02Local Directory\x02Add\x02Port\x02Open Port\x02Pr" +
-	"eferences\x02Master password\x02You can set a password to restrict acces" +
-	"s to this program.\x0aYou will be asked to enter it the next time you us" +
-	"e this program.\x02Use master password\x02Change Password\x02Languages" +
-	"\x02The current display language is\x02You must restart program to apply" +
-	" the modification.\x02Select language\x02Defaults\x02Define the default " +
-	"value when creating a new configuration.\x0aThe value here will not affe" +
-	"ct the existing configuration.\x02Set Defaults\x02Password removed.\x02N" +
-	"ew master password\x02Re-enter password\x02Password is set.\x02Log Level" +
-	"\x02Log retention\x02Quick Add\x02Remote Desktop\x02HTTP File Server\x02" +
-	"Enable\x02Open Config\x02Direct Edit\x02Domains\x02Copy Access Address" +
-	"\x02Delete proxy \x22%[1]s\x22\x02Are you sure you would like to delete " +
-	"proxy \x22%[1]s\x22?\x02Disable proxy \x22%[1]s\x22\x02Are you sure you " +
-	"would like to disable proxy \x22%[1]s\x22?\x02Disable\x02Passive Port Ra" +
-	"nge\x02FRP Manager\x02* Support batch import, one link per line.\x02Rena" +
-	"me automatically\x02Ready\x02Please enter the correct URL list.\x02Downl" +
-	"oad\x02Enter Password\x02You must enter an administration password to op" +
-	"erate the %[1]s.\x02Enter Administration Password\x02The password is inc" +
-	"orrect. Re-enter password.\x02Invalid Input\x02Please enter a number fro" +
-	"m %.[1]f to %.[2]f.\x02Please enter a number from %[1]s to %[2]s.\x02The" +
-	" text does not match the required pattern.\x02Selection Required\x02Plea" +
-	"se select one of the provided options.\x02A selection is required."
+	"\x02All\x02Common Only\x02Import Config\x02Import from File\x02Import fr" +
+	"om URL\x02Import from Clipboard\x02NAT Discovery\x02Copy Share Link\x02E" +
+	"xport All Configs to ZIP\x02Delete\x02New Config\x02Manual Settings\x02I" +
+	"mported %[1]d of %[2]d configs.\x02Another config already exists with th" +
+	"e name \x22%[1]s\x22.\x02The file \x22%[1]s\x22 is not a valid ZIP file." +
+	"\x02Delete config \x22%[1]s\x22\x02Are you sure you would like to delete" +
+	" config \x22%[1]s\x22?\x02New Client\x02Edit Client - %[1]s\x02Basic\x02" +
+	"Name\x02Server Address\x02Server Port\x02User\x02STUN Server\x02Auth\x02" +
+	"Auth Method\x02None\x02Token\x02Secret\x02Audience\x02Scope\x02Token End" +
+	"point\x02Authentication\x02Heart Beats\x02Work Conns\x02Log\x02* Leave b" +
+	"lank to record no log and delete the original log file.\x02Log File\x02S" +
+	"elect Log File\x02Level\x02Max Days\x02Admin\x02Admin Address\x02Admin P" +
+	"ort\x02Password\x02Assets\x02Select a local directory that the admin ser" +
+	"ver will load resources from.\x02Auto Delete\x02Absolute\x02Relative\x02" +
+	"Delete Date\x02Delete Days\x02Days\x02Connection\x02Protocol\x02HTTP Pro" +
+	"xy\x02Pool Count\x02Heartbeat\x02Interval\x02s\x02Timeout\x02Dial Timeou" +
+	"t\x02Keepalive\x02Idle Timeout\x02Max Streams\x02On\x02Off\x02Host Name" +
+	"\x02Certificate\x02Select Certificate File\x02Certificate Key\x02Select " +
+	"Certificate Key File\x02Trusted CA\x02Select Trusted CA File\x02Advanced" +
+	"\x02TCP Mux\x02Mux Keepalive\x02Source Address\x02Other Options\x02Exit " +
+	"after login failure\x02Disable auto-start at boot\x02Custom\x02Custom Op" +
+	"tions\x02* Refer to the [common] section of the FRP configuration file." +
+	"\x02Config already exists\x02The config name \x22%[1]s\x22 already exist" +
+	"s.\x02New Proxy\x02Edit Proxy - %[1]s\x02Random\x02Type\x02Role\x02Visit" +
+	"or\x02Secret Key\x02Local Address\x02Local Port\x02Remote Port\x02Bind A" +
+	"ddress\x02Bind Port\x02Server Name\x02Subdomain\x02Custom Domains\x02Loc" +
+	"ations\x02Multiplexer\x02Route User\x02Client\x02Server\x02Bandwidth\x02" +
+	"Proxy Version\x02Empty\x02Encryption\x02Compression\x02HTTP User\x02HTTP" +
+	" Password\x02Host Rewrite\x02Plugin\x02Plugin Name\x02Unix Path\x02Selec" +
+	"t Unix Path\x02Local Path\x02Select a folder for directory listing.\x02S" +
+	"trip Prefix\x02Load Balance\x02Group\x02Group Key\x02Health Check\x02Che" +
+	"ck Type\x02Check Timeout\x02Failure Count\x02Check Interval\x02* Refer t" +
+	"o the parameters supported by FRP.\x02Proxy already exists\x02The proxy " +
+	"name \x22%[1]s\x22 already exists.\x02Open Log Folder\x02Latest\x02Item" +
+	"\x02Value\x02NAT Type\x02Behavior\x02External Address\x02Yes\x02No\x02Pu" +
+	"blic Network\x02Unknown\x02Running\x02Stopped\x02Starting\x02Stopping" +
+	"\x02Status\x02Remote Address\x02Copy\x02Start\x02Service\x02Stop\x02Loca" +
+	"l Directory\x02Add\x02Port\x02Open Port\x02Preferences\x02Master passwor" +
+	"d\x02You can set a password to restrict access to this program.\x0aYou w" +
+	"ill be asked to enter it the next time you use this program.\x02Use mast" +
+	"er password\x02Change Password\x02Languages\x02The current display langu" +
+	"age is\x02You must restart program to apply the modification.\x02Select " +
+	"language\x02Defaults\x02Define the default value when creating a new con" +
+	"figuration.\x0aThe value here will not affect the existing configuration" +
+	".\x02Set Defaults\x02Password removed.\x02New master password\x02Re-ente" +
+	"r password\x02Password is set.\x02Log Level\x02Log retention\x02Quick Ad" +
+	"d\x02Remote Desktop\x02HTTP File Server\x02Enable\x02Open Config\x02Dire" +
+	"ct Edit\x02Domains\x02Copy Access Address\x02Delete proxy \x22%[1]s\x22" +
+	"\x02Are you sure you would like to delete proxy \x22%[1]s\x22?\x02Disabl" +
+	"e proxy \x22%[1]s\x22\x02Are you sure you would like to disable proxy " +
+	"\x22%[1]s\x22?\x02Disable\x02Passive Port Range\x02FRP Manager\x02* Supp" +
+	"ort batch import, one link per line.\x02Rename automatically\x02Ready" +
+	"\x02Please enter the correct URL list.\x02Download\x02Enter Password\x02" +
+	"You must enter an administration password to operate the %[1]s.\x02Enter" +
+	" Administration Password\x02The password is incorrect. Re-enter password" +
+	".\x02Invalid Input\x02Please enter a number from %.[1]f to %.[2]f.\x02Pl" +
+	"ease enter a number from %[1]s to %[2]s.\x02The text does not match the " +
+	"required pattern.\x02Selection Required\x02Please select one of the prov" +
+	"ided options.\x02A selection is required."
 
-var es_ESIndex = []uint32{ // 232 elements
+var es_ESIndex = []uint32{ // 242 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000010, 0x00000024, 0x00000041,
 	0x00000054, 0x0000006f, 0x00000087, 0x00000096,
@@ -428,64 +443,67 @@ var es_ESIndex = []uint32{ // 232 elements
 	0x00000330, 0x0000034c, 0x00000376, 0x0000037d,
 	// Entry 20 - 3F
 	0x0000038d, 0x000003a3, 0x000003b3, 0x000003b9,
-	0x000003c5, 0x000003dc, 0x000003ef, 0x0000040b,
-	0x00000423, 0x0000044c, 0x00000453, 0x00000460,
-	0x00000471, 0x00000489, 0x000004b3, 0x000004e8,
-	0x00000519, 0x00000539, 0x00000579, 0x00000587,
-	0x0000059e, 0x000005a6, 0x000005ad, 0x000005c5,
-	0x000005d8, 0x000005e0, 0x000005e5, 0x000005ed,
-	0x000005f5, 0x00000600, 0x00000608, 0x00000612,
+	0x000003c5, 0x000003dd, 0x000003f4, 0x00000407,
+	0x00000423, 0x00000435, 0x0000044d, 0x00000476,
+	0x0000047d, 0x0000048a, 0x0000049b, 0x000004c5,
+	0x000004fa, 0x0000052b, 0x0000054b, 0x0000058b,
+	0x00000599, 0x000005b0, 0x000005b8, 0x000005bf,
+	0x000005d7, 0x000005ea, 0x000005f2, 0x00000600,
+	0x00000605, 0x0000060d, 0x00000615, 0x00000620,
 	// Entry 40 - 5F
-	0x0000061a, 0x0000062e, 0x0000063d, 0x00000652,
-	0x00000667, 0x00000670, 0x000006d3, 0x000006e7,
-	0x00000707, 0x0000070d, 0x0000071c, 0x00000722,
-	0x0000072d, 0x00000734, 0x0000073a, 0x00000742,
-	0x000007a4, 0x000007bd, 0x000007c6, 0x000007cf,
-	0x000007de, 0x000007ed, 0x000007f3, 0x000007fd,
-	0x00000807, 0x00000812, 0x00000822, 0x00000836,
-	0x00000840, 0x00000842, 0x00000850, 0x00000862,
+	0x00000628, 0x00000632, 0x0000063a, 0x0000064e,
+	0x0000065d, 0x00000672, 0x00000687, 0x00000690,
+	0x000006f3, 0x00000707, 0x00000727, 0x0000072d,
+	0x0000073c, 0x00000742, 0x0000074d, 0x00000754,
+	0x0000075a, 0x00000762, 0x000007c4, 0x000007dd,
+	0x000007e6, 0x000007ef, 0x000007fe, 0x0000080d,
+	0x00000813, 0x0000081d, 0x00000827, 0x00000832,
+	0x00000842, 0x00000856, 0x00000860, 0x00000862,
 	// Entry 60 - 7F
-	0x0000086c, 0x00000882, 0x00000896, 0x0000089f,
-	0x000008a7, 0x000008bc, 0x000008c8, 0x000008eb,
-	0x00000900, 0x0000092c, 0x0000093c, 0x00000960,
-	0x00000969, 0x00000971, 0x0000097f, 0x00000997,
-	0x000009a6, 0x000009d4, 0x00000a01, 0x00000a09,
-	0x00000a21, 0x00000a67, 0x00000a83, 0x00000ab2,
-	0x00000abe, 0x00000ad3, 0x00000add, 0x00000ae2,
-	0x00000ae7, 0x00000af1, 0x00000aff, 0x00000b10,
+	0x00000870, 0x00000882, 0x0000088c, 0x000008a2,
+	0x000008b6, 0x000008bf, 0x000008c7, 0x000008dc,
+	0x000008e8, 0x0000090b, 0x00000920, 0x0000094c,
+	0x0000095c, 0x00000980, 0x00000989, 0x00000991,
+	0x0000099f, 0x000009b7, 0x000009c6, 0x000009f4,
+	0x00000a21, 0x00000a29, 0x00000a41, 0x00000a87,
+	0x00000aa3, 0x00000ad2, 0x00000ade, 0x00000af3,
+	0x00000afd, 0x00000b02, 0x00000b07, 0x00000b11,
 	// Entry 80 - 9F
-	0x00000b1d, 0x00000b2b, 0x00000b40, 0x00000b51,
-	0x00000b65, 0x00000b70, 0x00000b88, 0x00000b91,
-	0x00000b9d, 0x00000bad, 0x00000bb5, 0x00000bbe,
-	0x00000bca, 0x00000bdc, 0x00000be3, 0x00000beb,
-	0x00000bf7, 0x00000c04, 0x00000c15, 0x00000c29,
-	0x00000c32, 0x00000c39, 0x00000c43, 0x00000c5e,
-	0x00000c69, 0x00000c9e, 0x00000cae, 0x00000cc2,
-	0x00000cc8, 0x00000cd7, 0x00000ce8, 0x00000ced,
+	0x00000b1f, 0x00000b30, 0x00000b3d, 0x00000b4b,
+	0x00000b60, 0x00000b71, 0x00000b85, 0x00000b90,
+	0x00000ba8, 0x00000bb1, 0x00000bbd, 0x00000bcd,
+	0x00000bd5, 0x00000bde, 0x00000bea, 0x00000bfc,
+	0x00000c03, 0x00000c0b, 0x00000c17, 0x00000c24,
+	0x00000c35, 0x00000c49, 0x00000c52, 0x00000c59,
+	0x00000c63, 0x00000c7e, 0x00000c89, 0x00000cbe,
+	0x00000cce, 0x00000ce2, 0x00000ce8, 0x00000cf7,
 	// Entry A0 - BF
-	0x00000d01, 0x00000d14, 0x00000d1e, 0x00000d4c,
-	0x00000d5f, 0x00000d85, 0x00000d94, 0x00000d9c,
-	0x00000da8, 0x00000daf, 0x00000db8, 0x00000dc3,
-	0x00000dca, 0x00000dd1, 0x00000de3, 0x00000dea,
-	0x00000df3, 0x00000dfc, 0x00000e07, 0x00000e18,
-	0x00000e20, 0x00000e27, 0x00000e36, 0x00000e43,
-	0x00000e57, 0x00000ee7, 0x00000f00, 0x00000f17,
-	0x00000f1f, 0x00000f45, 0x00000f7f, 0x00000f94,
+	0x00000d08, 0x00000d0d, 0x00000d21, 0x00000d34,
+	0x00000d3e, 0x00000d6c, 0x00000d7f, 0x00000da5,
+	0x00000db4, 0x00000dbc, 0x00000dc2, 0x00000dcc,
+	0x00000dd8, 0x00000de7, 0x00000dfa, 0x00000dfe,
+	0x00000e01, 0x00000e0e, 0x00000e1a, 0x00000e21,
+	0x00000e2a, 0x00000e35, 0x00000e3c, 0x00000e43,
+	0x00000e55, 0x00000e5c, 0x00000e65, 0x00000e6e,
+	0x00000e79, 0x00000e8a, 0x00000e92, 0x00000e99,
 	// Entry C0 - DF
-	0x00000fa4, 0x0000101f, 0x0000102e, 0x00001045,
-	0x0000105f, 0x0000107f, 0x000010a1, 0x000010b3,
-	0x000010cb, 0x000010db, 0x000010ed, 0x00001107,
-	0x00001111, 0x00001126, 0x00001137, 0x00001140,
-	0x0000115c, 0x00001173, 0x000011aa, 0x000011c5,
-	0x000011fe, 0x0000120b, 0x00001223, 0x00001238,
-	0x0000126f, 0x0000128a, 0x00001290, 0x000012b5,
-	0x000012bf, 0x000012d9, 0x0000131d, 0x00001347,
+	0x00000ea8, 0x00000eb5, 0x00000ec9, 0x00000f59,
+	0x00000f72, 0x00000f89, 0x00000f91, 0x00000fb7,
+	0x00000ff1, 0x00001006, 0x00001016, 0x00001091,
+	0x000010a0, 0x000010b7, 0x000010d1, 0x000010f1,
+	0x00001113, 0x00001125, 0x0000113d, 0x0000114d,
+	0x0000115f, 0x00001179, 0x00001183, 0x00001198,
+	0x000011a9, 0x000011b2, 0x000011ce, 0x000011e5,
+	0x0000121c, 0x00001237, 0x00001270, 0x0000127d,
 	// Entry E0 - FF
-	0x00001386, 0x00001397, 0x000013be, 0x000013e3,
-	0x00001412, 0x00001427, 0x00001456, 0x00001472,
-} // Size: 952 bytes
+	0x00001295, 0x000012aa, 0x000012e1, 0x000012fc,
+	0x00001302, 0x00001327, 0x00001331, 0x0000134b,
+	0x0000138f, 0x000013b9, 0x000013f8, 0x00001409,
+	0x00001430, 0x00001455, 0x00001484, 0x00001499,
+	0x000014c8, 0x000014e4,
+} // Size: 992 bytes
 
-const es_ESData string = "" + // Size: 5234 bytes
+const es_ESData string = "" + // Size: 5348 bytes
 	"\x02Versión: %[1]s\x02Versión FRP: %[1]s\x02Fecha de compilación: %[1]s" +
 	"\x02Todos los archivos\x02Archivos de configuración\x02Archivos de certi" +
 	"ficado\x02Archivos clave\x02Archivos de registro\x02Número fuera del ran" +
@@ -500,77 +518,78 @@ const es_ESData string = "" + // Size: 5234 bytes
 	"\x02Cancelar\x02Configuración\x02Nueva Configuración\x02Importar configu" +
 	"ración desde archivo\x02Configuración ya eliminada\x02La configuración " +
 	"\x22%[1]s\x22 ya se eliminó.\x02Editar\x02Abrir documento\x02Mostrar en " +
-	"la carpeta\x02Crear una copia\x02Todos\x02Solo común\x02Importar desde a" +
-	"rchivo\x02Importar desde URL\x02Importar desde portapapeles\x02Copiar co" +
-	"mpartir enlace\x02Exportar todas las configuraciones a ZIP\x02Borrar\x02" +
-	"Nueva Config\x02Ajustes manuales\x02Importar configuración\x02Importado " +
-	"%[1]d de %[2]d configuraciones.\x02Ya existe otra configuración con el n" +
-	"ombre \x22%[1]s\x22.\x02El archivo \x22%[1]s\x22 no es un archivo ZIP vá" +
-	"lido.\x02Eliminar configuración \x22%[1]s\x22\x02¿Está seguro de que des" +
-	"ea eliminar la configuración \x22%[1]s\x22?\x02Nuevo Cliente\x02Editar C" +
-	"liente - %[1]s\x02Básico\x02Nombre\x02Dirección del servidor\x02Puerto d" +
-	"e servicio\x02Usuario\x02Auth\x02Método\x02Ninguna\x02Simbólico\x02Secre" +
-	"to\x02Audiencia\x02Alcance\x02Dirección de token\x02Autenticación\x02Lat" +
-	"idos del corazón\x02Conexión de trabajo\x02Registro\x02* Déjelo en blanc" +
-	"o para no registrar ningún registro y eliminar el archivo de registro or" +
-	"iginal.\x02Archivo de registro\x02Seleccionar archivo de registro\x02Niv" +
-	"el\x02Días máximos\x02Admin\x02Dirección\x02Puerto\x02Clave\x02Recurso" +
-	"\x02Seleccione un directorio local desde el que el servidor de administr" +
-	"ación cargará los recursos.\x02Eliminación automática\x02Absoluto\x02Rel" +
-	"ativo\x02Eliminar fecha\x02Eliminar días\x02Días\x02Conexión\x02Protocol" +
-	"o\x02Proxy HTTP\x02Conectar cuenta\x02Latido del corazón\x02Intervalo" +
-	"\x02s\x02Tiempo muerto\x02Conexión agotado\x02Keepalive\x02Tiempo de ina" +
-	"ctividad\x02Corrientes máximas\x02Encender\x02Apagado\x02Nombre de anfit" +
-	"rión\x02Certificado\x02Seleccionar archivo de certificado\x02Clave de ce" +
-	"rtificado\x02Seleccionar archivo de clave de certificado\x02CA de confia" +
-	"nza\x02Seleccionar archivo CA de confianza\x02Avanzado\x02Mux TCP\x02Mux" +
-	" Keepalive\x02Dirección de la fuente\x02Otras opciones\x02Salir después " +
-	"de fallar el inicio de sesión\x02Desactivar el inicio automático al arra" +
-	"ncar\x02Disfraz\x02Opciones personalizadas\x02* Consulte la sección [com" +
-	"mon] del archivo de configuración de FRP.\x02La configuración ya existe" +
-	"\x02El nombre de configuración \x22%[1]s\x22 ya existe.\x02Nuevo Proxy" +
-	"\x02Editar Proxy - %[1]s\x02Aleatorio\x02Tipo\x02Role\x02Visitante\x02Ll" +
-	"ave secreta\x02Dirección local\x02Puerto local\x02Puerto remoto\x02Direc" +
-	"ción de enlace\x02Puerto de enlace\x02Nombre del servidor\x02Subdominio" +
-	"\x02Dominios personalizados\x02Ruta URL\x02Multiplexor\x02Usuario de rut" +
-	"a\x02Cliente\x02Servidor\x02Banda ancha\x02Versión de proxy\x02Vacío\x02" +
-	"Cifrado\x02Compresión\x02Usuario HTTP\x02Contraseña HTTP\x02Reescritura " +
-	"de host\x02Enchufar\x02Nombre\x02Ruta Unix\x02Seleccione la ruta de Unix" +
-	"\x02Ruta local\x02Seleccione una carpeta para la lista de directorios." +
-	"\x02Prefijo de tira\x02Equilibrio de carga\x02Grupo\x02Clave de grupo" +
-	"\x02Chequeo de salud\x02Tipo\x02Se acabó el tiempo\x02Recuento de fallas" +
-	"\x02Intervalo\x02* Consulte los parámetros admitidos por FRP.\x02El prox" +
-	"y ya existe\x02El nombre de proxy \x22%[1]s\x22 ya existe.\x02Abrir regi" +
-	"stro\x02Último\x02Desconocido\x02Correr\x02Detenido\x02Comenzando\x02Par" +
-	"ada\x02Estado\x02Dirección remota\x02Copiar\x02Comienzo\x02Servicio\x02D" +
-	"eténgase\x02Directorio local\x02Agregar\x02Puerto\x02Puerto abierto\x02P" +
-	"referencias\x02Contraseña maestra\x02Puede establecer una contraseña par" +
-	"a restringir el acceso a este programa.\x0aSe le pedirá que lo ingrese l" +
-	"a próxima vez que use este programa.\x02Usar contraseña maestra\x02Cambi" +
-	"ar la contraseña\x02Idiomas\x02El idioma de visualización actual es\x02D" +
-	"ebe reiniciar el programa para aplicar la modificación.\x02Seleccione el" +
-	" idioma\x02Predeterminados\x02Defina el valor predeterminado al crear un" +
-	"a nueva configuración.\x0aEl valor aquí no afectará la configuración exi" +
-	"stente.\x02Valor ajustado\x02Contraseña eliminada.\x02Nueva contraseña m" +
-	"aestra\x02Escriba la contraseña otra vez\x02La contraseña está configura" +
-	"da.\x02Nivel de registro\x02Retención de registros\x02Añadir rápido\x02E" +
-	"scritorio remoto\x02Servidor de archivos HTTP\x02Habilitar\x02Abrir conf" +
-	"iguración\x02Edición directa\x02Dominios\x02Copiar dirección de acceso" +
-	"\x02Eliminar proxy \x22%[1]s\x22\x02¿Está seguro de que desea eliminar e" +
-	"l proxy \x22%[1]s\x22?\x02Deshabilitar proxy \x22%[1]s\x22\x02¿Está segu" +
-	"ro de que desea desactivar el proxy \x22%[1]s\x22?\x02Deshabilitar\x02Ga" +
-	"ma de puertos pasivos\x02Administrador de FRP\x02* Admite importación po" +
-	"r lotes, un enlace por línea.\x02Renombrar automáticamente\x02Listo\x02I" +
-	"ntroduzca la lista de URL correcta.\x02Descargar\x02Introducir la contra" +
-	"seña\x02Debe ingresar una contraseña de administración para operar %[1]s" +
-	".\x02Ingrese la contraseña de administración\x02La contraseña es incorre" +
-	"cta. Escriba la contraseña otra vez.\x02Entrada invalida\x02Ingrese un n" +
-	"úmero de %.[1]f a %.[2]f.\x02Ingrese un número de %[1]s a %[2]s.\x02El " +
-	"texto no coincide con el patrón requerido.\x02Selección requerida\x02Sel" +
-	"eccione una de las opciones proporcionadas.\x02Se requiere una selección" +
-	"."
+	"la carpeta\x02Crear una copia\x02Todos\x02Solo común\x02Importar configu" +
+	"ración\x02Importar desde archivo\x02Importar desde URL\x02Importar desde" +
+	" portapapeles\x02Detección de NAT\x02Copiar compartir enlace\x02Exportar" +
+	" todas las configuraciones a ZIP\x02Borrar\x02Nueva Config\x02Ajustes ma" +
+	"nuales\x02Importado %[1]d de %[2]d configuraciones.\x02Ya existe otra co" +
+	"nfiguración con el nombre \x22%[1]s\x22.\x02El archivo \x22%[1]s\x22 no " +
+	"es un archivo ZIP válido.\x02Eliminar configuración \x22%[1]s\x22\x02¿Es" +
+	"tá seguro de que desea eliminar la configuración \x22%[1]s\x22?\x02Nuevo" +
+	" Cliente\x02Editar Cliente - %[1]s\x02Básico\x02Nombre\x02Dirección del " +
+	"servidor\x02Puerto de servicio\x02Usuario\x02Servidor STUN\x02Auth\x02Mé" +
+	"todo\x02Ninguna\x02Simbólico\x02Secreto\x02Audiencia\x02Alcance\x02Direc" +
+	"ción de token\x02Autenticación\x02Latidos del corazón\x02Conexión de tra" +
+	"bajo\x02Registro\x02* Déjelo en blanco para no registrar ningún registro" +
+	" y eliminar el archivo de registro original.\x02Archivo de registro\x02S" +
+	"eleccionar archivo de registro\x02Nivel\x02Días máximos\x02Admin\x02Dire" +
+	"cción\x02Puerto\x02Clave\x02Recurso\x02Seleccione un directorio local de" +
+	"sde el que el servidor de administración cargará los recursos.\x02Elimin" +
+	"ación automática\x02Absoluto\x02Relativo\x02Eliminar fecha\x02Eliminar d" +
+	"ías\x02Días\x02Conexión\x02Protocolo\x02Proxy HTTP\x02Conectar cuenta" +
+	"\x02Latido del corazón\x02Intervalo\x02s\x02Tiempo muerto\x02Conexión ag" +
+	"otado\x02Keepalive\x02Tiempo de inactividad\x02Corrientes máximas\x02Enc" +
+	"ender\x02Apagado\x02Nombre de anfitrión\x02Certificado\x02Seleccionar ar" +
+	"chivo de certificado\x02Clave de certificado\x02Seleccionar archivo de c" +
+	"lave de certificado\x02CA de confianza\x02Seleccionar archivo CA de conf" +
+	"ianza\x02Avanzado\x02Mux TCP\x02Mux Keepalive\x02Dirección de la fuente" +
+	"\x02Otras opciones\x02Salir después de fallar el inicio de sesión\x02Des" +
+	"activar el inicio automático al arrancar\x02Disfraz\x02Opciones personal" +
+	"izadas\x02* Consulte la sección [common] del archivo de configuración de" +
+	" FRP.\x02La configuración ya existe\x02El nombre de configuración \x22%[" +
+	"1]s\x22 ya existe.\x02Nuevo Proxy\x02Editar Proxy - %[1]s\x02Aleatorio" +
+	"\x02Tipo\x02Role\x02Visitante\x02Llave secreta\x02Dirección local\x02Pue" +
+	"rto local\x02Puerto remoto\x02Dirección de enlace\x02Puerto de enlace" +
+	"\x02Nombre del servidor\x02Subdominio\x02Dominios personalizados\x02Ruta" +
+	" URL\x02Multiplexor\x02Usuario de ruta\x02Cliente\x02Servidor\x02Banda a" +
+	"ncha\x02Versión de proxy\x02Vacío\x02Cifrado\x02Compresión\x02Usuario HT" +
+	"TP\x02Contraseña HTTP\x02Reescritura de host\x02Enchufar\x02Nombre\x02Ru" +
+	"ta Unix\x02Seleccione la ruta de Unix\x02Ruta local\x02Seleccione una ca" +
+	"rpeta para la lista de directorios.\x02Prefijo de tira\x02Equilibrio de " +
+	"carga\x02Grupo\x02Clave de grupo\x02Chequeo de salud\x02Tipo\x02Se acabó" +
+	" el tiempo\x02Recuento de fallas\x02Intervalo\x02* Consulte los parámetr" +
+	"os admitidos por FRP.\x02El proxy ya existe\x02El nombre de proxy \x22%[" +
+	"1]s\x22 ya existe.\x02Abrir registro\x02Último\x02Ítem\x02Valorizar\x02T" +
+	"ipo de NAT\x02Comportamiento\x02Dirección externa\x02Sí\x02No\x02Red púb" +
+	"lica\x02Desconocido\x02Correr\x02Detenido\x02Comenzando\x02Parada\x02Est" +
+	"ado\x02Dirección remota\x02Copiar\x02Comienzo\x02Servicio\x02Deténgase" +
+	"\x02Directorio local\x02Agregar\x02Puerto\x02Puerto abierto\x02Preferenc" +
+	"ias\x02Contraseña maestra\x02Puede establecer una contraseña para restri" +
+	"ngir el acceso a este programa.\x0aSe le pedirá que lo ingrese la próxim" +
+	"a vez que use este programa.\x02Usar contraseña maestra\x02Cambiar la co" +
+	"ntraseña\x02Idiomas\x02El idioma de visualización actual es\x02Debe rein" +
+	"iciar el programa para aplicar la modificación.\x02Seleccione el idioma" +
+	"\x02Predeterminados\x02Defina el valor predeterminado al crear una nueva" +
+	" configuración.\x0aEl valor aquí no afectará la configuración existente." +
+	"\x02Valor ajustado\x02Contraseña eliminada.\x02Nueva contraseña maestra" +
+	"\x02Escriba la contraseña otra vez\x02La contraseña está configurada." +
+	"\x02Nivel de registro\x02Retención de registros\x02Añadir rápido\x02Escr" +
+	"itorio remoto\x02Servidor de archivos HTTP\x02Habilitar\x02Abrir configu" +
+	"ración\x02Edición directa\x02Dominios\x02Copiar dirección de acceso\x02E" +
+	"liminar proxy \x22%[1]s\x22\x02¿Está seguro de que desea eliminar el pro" +
+	"xy \x22%[1]s\x22?\x02Deshabilitar proxy \x22%[1]s\x22\x02¿Está seguro de" +
+	" que desea desactivar el proxy \x22%[1]s\x22?\x02Deshabilitar\x02Gama de" +
+	" puertos pasivos\x02Administrador de FRP\x02* Admite importación por lot" +
+	"es, un enlace por línea.\x02Renombrar automáticamente\x02Listo\x02Introd" +
+	"uzca la lista de URL correcta.\x02Descargar\x02Introducir la contraseña" +
+	"\x02Debe ingresar una contraseña de administración para operar %[1]s." +
+	"\x02Ingrese la contraseña de administración\x02La contraseña es incorrec" +
+	"ta. Escriba la contraseña otra vez.\x02Entrada invalida\x02Ingrese un nú" +
+	"mero de %.[1]f a %.[2]f.\x02Ingrese un número de %[1]s a %[2]s.\x02El te" +
+	"xto no coincide con el patrón requerido.\x02Selección requerida\x02Selec" +
+	"cione una de las opciones proporcionadas.\x02Se requiere una selección."
 
-var ja_JPIndex = []uint32{ // 232 elements
+var ja_JPIndex = []uint32{ // 242 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000018, 0x00000034, 0x0000004f,
 	0x00000068, 0x0000007b, 0x00000091, 0x000000a7,
@@ -582,64 +601,67 @@ var ja_JPIndex = []uint32{ // 232 elements
 	0x000003db, 0x00000406, 0x0000043c, 0x00000443,
 	// Entry 20 - 3F
 	0x00000459, 0x0000046f, 0x00000488, 0x0000048f,
-	0x000004a2, 0x000004c4, 0x000004dd, 0x00000508,
-	0x00000524, 0x00000552, 0x00000559, 0x00000569,
-	0x00000576, 0x0000058f, 0x000005d0, 0x00000612,
-	0x0000065b, 0x00000674, 0x000006a5, 0x000006c1,
-	0x000006e5, 0x000006ec, 0x000006f3, 0x0000070c,
-	0x0000071f, 0x0000072c, 0x00000733, 0x00000740,
-	0x00000747, 0x00000754, 0x0000075e, 0x00000768,
+	0x000004a2, 0x000004bb, 0x000004dd, 0x000004f6,
+	0x00000521, 0x0000052c, 0x00000548, 0x00000576,
+	0x0000057d, 0x0000058d, 0x0000059a, 0x000005db,
+	0x0000061d, 0x00000666, 0x0000067f, 0x000006b0,
+	0x000006cc, 0x000006f0, 0x000006f7, 0x000006fe,
+	0x00000717, 0x0000072a, 0x00000737, 0x00000748,
+	0x0000074f, 0x0000075c, 0x00000763, 0x00000770,
 	// Entry 40 - 5F
-	0x0000076f, 0x00000782, 0x00000789, 0x00000799,
-	0x000007a6, 0x000007ad, 0x00000816, 0x00000829,
-	0x00000845, 0x0000084f, 0x0000085c, 0x00000866,
-	0x0000087c, 0x0000088c, 0x0000089c, 0x000008a3,
-	0x0000090a, 0x00000917, 0x0000091e, 0x00000925,
-	0x0000092f, 0x0000093c, 0x00000940, 0x00000947,
-	0x00000957, 0x00000969, 0x0000097f, 0x00000992,
-	0x00000999, 0x0000099b, 0x000009ae, 0x000009c7,
+	0x0000077a, 0x00000784, 0x0000078b, 0x0000079e,
+	0x000007a5, 0x000007b5, 0x000007c2, 0x000007c9,
+	0x00000832, 0x00000845, 0x00000861, 0x0000086b,
+	0x00000878, 0x00000882, 0x00000898, 0x000008a8,
+	0x000008b8, 0x000008bf, 0x00000926, 0x00000933,
+	0x0000093a, 0x00000941, 0x0000094b, 0x00000958,
+	0x0000095c, 0x00000963, 0x00000973, 0x00000985,
+	0x0000099b, 0x000009ae, 0x000009b5, 0x000009b7,
 	// Entry 60 - 7F
-	0x000009d7, 0x000009f6, 0x00000a0c, 0x00000a13,
-	0x00000a1a, 0x00000a27, 0x00000a31, 0x00000a50,
-	0x00000a60, 0x00000a8e, 0x00000aa1, 0x00000ad3,
-	0x00000ada, 0x00000ae4, 0x00000afd, 0x00000b13,
-	0x00000b29, 0x00000b48, 0x00000b73, 0x00000b80,
-	0x00000b9c, 0x00000bef, 0x00000c11, 0x00000c3f,
-	0x00000c55, 0x00000c73, 0x00000c80, 0x00000c8a,
-	0x00000c91, 0x00000c9e, 0x00000ca8, 0x00000cc1,
+	0x000009ca, 0x000009e3, 0x000009f3, 0x00000a12,
+	0x00000a28, 0x00000a2f, 0x00000a36, 0x00000a43,
+	0x00000a4d, 0x00000a6c, 0x00000a7c, 0x00000aaa,
+	0x00000abd, 0x00000aef, 0x00000af6, 0x00000b00,
+	0x00000b19, 0x00000b2f, 0x00000b45, 0x00000b64,
+	0x00000b8f, 0x00000b9c, 0x00000bb8, 0x00000c0b,
+	0x00000c2d, 0x00000c5b, 0x00000c71, 0x00000c8f,
+	0x00000c9c, 0x00000ca6, 0x00000cad, 0x00000cba,
 	// Entry 80 - 9F
-	0x00000cd7, 0x00000ced, 0x00000d06, 0x00000d1c,
-	0x00000d2c, 0x00000d3f, 0x00000d58, 0x00000d6f,
-	0x00000d85, 0x00000d9b, 0x00000dae, 0x00000db8,
-	0x00000dc2, 0x00000dd2, 0x00000dd6, 0x00000de0,
-	0x00000de7, 0x00000df9, 0x00000e0e, 0x00000e27,
-	0x00000e37, 0x00000e4a, 0x00000e56, 0x00000e6b,
-	0x00000e7e, 0x00000ebe, 0x00000edd, 0x00000eea,
-	0x00000ef7, 0x00000f0d, 0x00000f1a, 0x00000f24,
+	0x00000cc4, 0x00000cdd, 0x00000cf3, 0x00000d09,
+	0x00000d22, 0x00000d38, 0x00000d48, 0x00000d5b,
+	0x00000d74, 0x00000d8b, 0x00000da1, 0x00000db7,
+	0x00000dca, 0x00000dd4, 0x00000dde, 0x00000dee,
+	0x00000df2, 0x00000dfc, 0x00000e03, 0x00000e15,
+	0x00000e2a, 0x00000e43, 0x00000e53, 0x00000e66,
+	0x00000e72, 0x00000e87, 0x00000e9a, 0x00000eda,
+	0x00000ef9, 0x00000f06, 0x00000f13, 0x00000f29,
 	// Entry A0 - BF
-	0x00000f37, 0x00000f41, 0x00000f54, 0x00000f8e,
-	0x00000fb6, 0x00000fea, 0x00001006, 0x0000100d,
-	0x0000101d, 0x0000102d, 0x00001034, 0x0000103b,
-	0x00001042, 0x00001049, 0x00001062, 0x0000106c,
-	0x00001076, 0x00001083, 0x0000108d, 0x0000109a,
-	0x000010a1, 0x000010ab, 0x000010bb, 0x000010c8,
-	0x000010e4, 0x000011a0, 0x000011cb, 0x000011ea,
-	0x000011f1, 0x0000120a, 0x00001262, 0x00001278,
+	0x00000f36, 0x00000f40, 0x00000f53, 0x00000f5d,
+	0x00000f70, 0x00000faa, 0x00000fd2, 0x00001006,
+	0x00001022, 0x00001029, 0x00001030, 0x00001034,
+	0x00001042, 0x00001049, 0x0000105c, 0x00001063,
+	0x0000106d, 0x00001089, 0x00001099, 0x000010a9,
+	0x000010b0, 0x000010b7, 0x000010be, 0x000010c5,
+	0x000010de, 0x000010e8, 0x000010f2, 0x000010ff,
+	0x00001109, 0x00001116, 0x0000111d, 0x00001127,
 	// Entry C0 - DF
-	0x00001288, 0x00001317, 0x00001330, 0x0000135b,
-	0x00001380, 0x0000138a, 0x000013b8, 0x000013c8,
-	0x000013d5, 0x000013e8, 0x00001407, 0x00001425,
-	0x0000142c, 0x0000143c, 0x00001449, 0x00001459,
-	0x0000147e, 0x000014a6, 0x000014dd, 0x00001505,
-	0x00001548, 0x0000154f, 0x0000156b, 0x0000157f,
-	0x000015de, 0x000015fa, 0x00001601, 0x00001635,
-	0x00001648, 0x00001667, 0x000016c2, 0x000016e4,
+	0x00001137, 0x00001144, 0x00001160, 0x0000121c,
+	0x00001247, 0x00001266, 0x0000126d, 0x00001286,
+	0x000012de, 0x000012f4, 0x00001304, 0x00001393,
+	0x000013ac, 0x000013d7, 0x000013fc, 0x00001406,
+	0x00001434, 0x00001444, 0x00001451, 0x00001464,
+	0x00001483, 0x000014a1, 0x000014a8, 0x000014b8,
+	0x000014c5, 0x000014d5, 0x000014fa, 0x00001522,
+	0x00001559, 0x00001581, 0x000015c4, 0x000015cb,
 	// Entry E0 - FF
-	0x0000172e, 0x0000173b, 0x0000177e, 0x000017bf,
-	0x000017fc, 0x00001809, 0x00001855, 0x0000186e,
-} // Size: 952 bytes
+	0x000015e7, 0x000015fb, 0x0000165a, 0x00001676,
+	0x0000167d, 0x000016b1, 0x000016c4, 0x000016e3,
+	0x0000173e, 0x00001760, 0x000017aa, 0x000017b7,
+	0x000017fa, 0x0000183b, 0x00001878, 0x00001885,
+	0x000018d1, 0x000018ea,
+} // Size: 992 bytes
 
-const ja_JPData string = "" + // Size: 6254 bytes
+const ja_JPData string = "" + // Size: 6378 bytes
 	"\x02バージョン：%[1]s\x02FRP バージョン：%[1]s\x02コンパイル日：%[1]s\x02すべてのファイル\x02設定ファイル" +
 	"\x02証明書ファイル\x02秘密鍵ファイル\x02ログファイル\x02許容範囲外の数値\x02%[1]d より大きい数値を入力してください。" +
 	"\x02パスワードの不一致\x02もう一度確認してください。\x02数字ではありません\x02有効な数値を入力してください。\x02新しいバージ" +
@@ -647,47 +669,48 @@ const ja_JPData string = "" + // Size: 6254 bytes
 	"トページにアクセスしてください：\x02FRP 設定ドキュメントについては、FRP プロジェクトページにアクセスしてください：\x02ソフト" +
 	"ウェアアップデートの確認中にエラーが発生しました。\x02現在、利用可能なアップデートはありません。\x02OK\x02キャンセル\x02設" +
 	"定\x02新しい設定\x02ファイルから設定をインポートする\x02設定はすでに削除されています\x02設定「%[1]s」は既に削除されてい" +
-	"ます。\x02編集\x02ファイルを開く\x02フォルダで見て\x02コピーを作成する\x02全て\x02共通設定のみ\x02ファイルからイ" +
-	"ンポート\x02URLからインポート\x02クリップボードからインポート\x02共有リンクをコピー\x02すべての設定をZIPにエクスポート" +
-	"\x02削除\x02新しい設定\x02手動設定\x02設定のインポート\x14\x02\x80\x01\x00;\x02%[2]d 中の %[1" +
-	"]d 設定をインポートしました。\x02\x22%[1]s\x22 という名前の別の設定が既に存在します。\x02ファイル \x22%[1]s" +
-	"\x22 は有効なZIPファイルではありません。\x02設定 \x22%[1]s\x22 を削除\x02本当に設定 \x22%[1]s\x22 " +
-	"を削除しますか？\x02新しいクライアント\x02クライアントの編集 - %[1]s\x02基本\x02名前\x02サーバーアドレス\x02" +
-	"サーバポート\x02ユーザー\x02認証\x02認証方法\x02なし\x02トークン\x02秘密鍵\x02受信者\x02範囲\x02トークン" +
-	"のURL\x02認証\x02接続を維持\x02作業接続\x02ログ\x02* ログを記録せず、元のログファイルを削除するには、空白のままにし" +
-	"ます。\x02ログファイル\x02ログファイルを選択\x02レベル\x02最大日数\x02管理者\x02管理者アドレス\x02管理ポート" +
-	"\x02パスワード\x02資産\x02管理サーバーがリソースをロードするローカルディレクトリを選択します。\x02自動削除\x02絶対\x02相" +
-	"対\x02削除日\x02日を削除\x02日\x02接続\x02プロトコル\x02HTTP プロキシ\x02接続プールの数\x02ハートビート" +
-	"\x02間隔\x02s\x02タイムアウト\x02接続タイムアウト\x02接続を維持\x02アイドルタイムアウト\x02最大ストリーム\x02有" +
-	"効\x02無効\x02ホスト名\x02証明書\x02証明書ファイルを選択\x02証明書キー\x02証明書キーファイルを選択します\x02信頼" +
-	"できる CA\x02信頼できる CA ファイルを選択します\x02高度\x02多重化\x02多重化接続を維持\x02送信元アドレス\x02別" +
-	"のオプション\x02ログイン失敗後に終了\x02起動時に自動起動を無効にする\x02カスタム\x02カスタムオプション\x02* FRP 設" +
-	"定ファイルの [common] セクションを参照してください。\x02設定はすでに存在します\x02設定名 \x22%[1]s\x22 は既" +
-	"に存在します。\x02新しいプロキシ\x02プロキシの編集 - %[1]s\x02ランダム\x02タイプ\x02役割\x02ビジター\x02" +
-	"秘密鍵\x02ローカルアドレス\x02ローカルポート\x02リモートポート\x02バインドアドレス\x02バインドポート\x02サーバー名" +
-	"\x02サブドメイン\x02カスタムドメイン\x02URL ルーティング\x02マルチプレクサ\x02ルートユーザー\x02クライアント\x02" +
-	"サーバ\x02帯域幅\x02プロキシ版\x02空\x02暗号化\x02圧縮\x02HTTP ユーザー\x02HTTP パスワード\x02ホス" +
-	"トの書き換え\x02プラグイン\x02プラグイン名\x02Unix パス\x02Unix パスを選択\x02ローカルパス\x02ディレクトリ" +
-	"リストのフォルダを選択します。\x02プレフィックスを削除\x02負荷平衡\x02グループ\x02グループ秘密鍵\x02健康診断\x02タイ" +
-	"プ\x02タイムアウト\x02失敗数\x02チェック間隔\x02* FRP 対応のパラメータをご参照ください。\x02プロキシはすでに存在し" +
-	"ます\x02プロキシ名 \x22%[1]s\x22 は既に存在します。\x02ログフォルダを開く\x02最新\x02わからない\x02ランニ" +
-	"ング\x02停止\x02起動\x02停止\x02状態\x02リモートアドレス\x02コピー\x02始める\x02サービス\x02止まる" +
-	"\x02フォルダ\x02追加\x02ポート\x02ポート開放\x02環境設定\x02マスターパスワード\x02パスワードを設定して、このプログラ" +
-	"ムへのアクセスを制限できます。\x0a次回このプログラムを使用するときに入力するよう求められます。\x02マスターパスワードを使用する" +
-	"\x02パスワードを変更する\x02言語\x02現在の表示言語は\x02変更を適用するには、プログラムを再起動する必要があります。\x02言語を" +
-	"選択する\x02デフォルト\x02新しい設定を作成するときのデフォルト値を定義します。\x0aここでの値は、既存の設定には影響しません。" +
-	"\x02デフォルトの設定\x02パスワードが解除されました。\x02新しいマスターパスワード\x02再入力\x02パスワードが設定されています。" +
-	"\x02ログレベル\x02ログ保持\x02クイック追加\x02リモートデスクトップ\x02HTTP ファイルサーバー\x02有効\x02設定を開" +
-	"く\x02直接編集\x02ドメイン名\x02アクセスアドレスのコピー\x02プロキシ \x22%[1]s\x22 を削除します\x02本当に" +
-	"プロキシ \x22%[1]s\x22 を削除しますか？\x02プロキシ \x22%[1]s\x22 を無効にする\x02プロキシ \x22%" +
-	"[1]s\x22 を無効にしてもよろしいですか？\x02無効\x02パッシブポート範囲\x02FRP マネージャ\x02* バッチインポートをサ" +
-	"ポートします、1行に1つのリンクがあります。\x02自動的に名前を変更\x02準備\x02正しいURLリストを入力してください。\x02ダウ" +
-	"ンロード\x02パスワードを入力する\x02%[1]s を操作するには、管理パスワードを入力する必要があります。\x02管理者パスワードを入" +
-	"力\x02パスワードが正しくありません。 パスワード再入力。\x02無効入力\x02%.[1]f から %.[2]f までの数字を入力してく" +
-	"ださい。\x02%[1]s から %[2]s までの数値を入力してください。\x02テキストが必要なパターンと一致しません。\x02選択必須" +
-	"\x02提供されたオプションのいずれかを選択してください。\x02選択が必要です。"
+	"ます。\x02編集\x02ファイルを開く\x02フォルダで見て\x02コピーを作成する\x02全て\x02共通設定のみ\x02設定のインポー" +
+	"ト\x02ファイルからインポート\x02URLからインポート\x02クリップボードからインポート\x02NAT 検出\x02共有リンクをコピ" +
+	"ー\x02すべての設定をZIPにエクスポート\x02削除\x02新しい設定\x02手動設定\x14\x02\x80\x01\x00;\x02" +
+	"%[2]d 中の %[1]d 設定をインポートしました。\x02\x22%[1]s\x22 という名前の別の設定が既に存在します。\x02ファイ" +
+	"ル \x22%[1]s\x22 は有効なZIPファイルではありません。\x02設定 \x22%[1]s\x22 を削除\x02本当に設定 " +
+	"\x22%[1]s\x22 を削除しますか？\x02新しいクライアント\x02クライアントの編集 - %[1]s\x02基本\x02名前\x02" +
+	"サーバーアドレス\x02サーバポート\x02ユーザー\x02STUNサーバー\x02認証\x02認証方法\x02なし\x02トークン\x02" +
+	"秘密鍵\x02受信者\x02範囲\x02トークンのURL\x02認証\x02接続を維持\x02作業接続\x02ログ\x02* ログを記録せず" +
+	"、元のログファイルを削除するには、空白のままにします。\x02ログファイル\x02ログファイルを選択\x02レベル\x02最大日数\x02管" +
+	"理者\x02管理者アドレス\x02管理ポート\x02パスワード\x02資産\x02管理サーバーがリソースをロードするローカルディレクトリを選" +
+	"択します。\x02自動削除\x02絶対\x02相対\x02削除日\x02日を削除\x02日\x02接続\x02プロトコル\x02HTTP プ" +
+	"ロキシ\x02接続プールの数\x02ハートビート\x02間隔\x02s\x02タイムアウト\x02接続タイムアウト\x02接続を維持\x02" +
+	"アイドルタイムアウト\x02最大ストリーム\x02有効\x02無効\x02ホスト名\x02証明書\x02証明書ファイルを選択\x02証明書キ" +
+	"ー\x02証明書キーファイルを選択します\x02信頼できる CA\x02信頼できる CA ファイルを選択します\x02高度\x02多重化" +
+	"\x02多重化接続を維持\x02送信元アドレス\x02別のオプション\x02ログイン失敗後に終了\x02起動時に自動起動を無効にする\x02カス" +
+	"タム\x02カスタムオプション\x02* FRP 設定ファイルの [common] セクションを参照してください。\x02設定はすでに存在し" +
+	"ます\x02設定名 \x22%[1]s\x22 は既に存在します。\x02新しいプロキシ\x02プロキシの編集 - %[1]s\x02ランダ" +
+	"ム\x02タイプ\x02役割\x02ビジター\x02秘密鍵\x02ローカルアドレス\x02ローカルポート\x02リモートポート\x02バイン" +
+	"ドアドレス\x02バインドポート\x02サーバー名\x02サブドメイン\x02カスタムドメイン\x02URL ルーティング\x02マルチプレ" +
+	"クサ\x02ルートユーザー\x02クライアント\x02サーバ\x02帯域幅\x02プロキシ版\x02空\x02暗号化\x02圧縮\x02HT" +
+	"TP ユーザー\x02HTTP パスワード\x02ホストの書き換え\x02プラグイン\x02プラグイン名\x02Unix パス\x02Unix " +
+	"パスを選択\x02ローカルパス\x02ディレクトリリストのフォルダを選択します。\x02プレフィックスを削除\x02負荷平衡\x02グループ" +
+	"\x02グループ秘密鍵\x02健康診断\x02タイプ\x02タイムアウト\x02失敗数\x02チェック間隔\x02* FRP 対応のパラメータを" +
+	"ご参照ください。\x02プロキシはすでに存在します\x02プロキシ名 \x22%[1]s\x22 は既に存在します。\x02ログフォルダを開" +
+	"く\x02最新\x02項目\x02値\x02NAT タイプ\x02挙動\x02外部アドレス\x02はい\x02いいえ\x02公共のネットワー" +
+	"ク\x02わからない\x02ランニング\x02停止\x02起動\x02停止\x02状態\x02リモートアドレス\x02コピー\x02始める" +
+	"\x02サービス\x02止まる\x02フォルダ\x02追加\x02ポート\x02ポート開放\x02環境設定\x02マスターパスワード\x02パス" +
+	"ワードを設定して、このプログラムへのアクセスを制限できます。\x0a次回このプログラムを使用するときに入力するよう求められます。\x02マス" +
+	"ターパスワードを使用する\x02パスワードを変更する\x02言語\x02現在の表示言語は\x02変更を適用するには、プログラムを再起動する必" +
+	"要があります。\x02言語を選択する\x02デフォルト\x02新しい設定を作成するときのデフォルト値を定義します。\x0aここでの値は、既存" +
+	"の設定には影響しません。\x02デフォルトの設定\x02パスワードが解除されました。\x02新しいマスターパスワード\x02再入力\x02パ" +
+	"スワードが設定されています。\x02ログレベル\x02ログ保持\x02クイック追加\x02リモートデスクトップ\x02HTTP ファイルサー" +
+	"バー\x02有効\x02設定を開く\x02直接編集\x02ドメイン名\x02アクセスアドレスのコピー\x02プロキシ \x22%[1]s" +
+	"\x22 を削除します\x02本当にプロキシ \x22%[1]s\x22 を削除しますか？\x02プロキシ \x22%[1]s\x22 を無効に" +
+	"する\x02プロキシ \x22%[1]s\x22 を無効にしてもよろしいですか？\x02無効\x02パッシブポート範囲\x02FRP マネー" +
+	"ジャ\x02* バッチインポートをサポートします、1行に1つのリンクがあります。\x02自動的に名前を変更\x02準備\x02正しいURLリ" +
+	"ストを入力してください。\x02ダウンロード\x02パスワードを入力する\x02%[1]s を操作するには、管理パスワードを入力する必要があ" +
+	"ります。\x02管理者パスワードを入力\x02パスワードが正しくありません。 パスワード再入力。\x02無効入力\x02%.[1]f から " +
+	"%.[2]f までの数字を入力してください。\x02%[1]s から %[2]s までの数値を入力してください。\x02テキストが必要なパターン" +
+	"と一致しません。\x02選択必須\x02提供されたオプションのいずれかを選択してください。\x02選択が必要です。"
 
-var ko_KRIndex = []uint32{ // 232 elements
+var ko_KRIndex = []uint32{ // 242 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000e, 0x00000020, 0x00000035,
 	0x00000043, 0x00000051, 0x00000062, 0x00000070,
@@ -699,64 +722,67 @@ var ko_KRIndex = []uint32{ // 232 elements
 	0x0000030d, 0x00000328, 0x00000358, 0x00000365,
 	// Entry 20 - 3F
 	0x00000373, 0x00000384, 0x00000395, 0x0000039c,
-	0x000003b4, 0x000003ce, 0x000003e5, 0x00000405,
-	0x0000041a, 0x00000443, 0x0000044a, 0x0000045b,
-	0x00000469, 0x0000047d, 0x000004b1, 0x000004ed,
-	0x00000525, 0x0000053b, 0x00000567, 0x0000057b,
-	0x0000059a, 0x000005a7, 0x000005ae, 0x000005bc,
-	0x000005ca, 0x000005d4, 0x000005db, 0x000005e9,
-	0x000005f0, 0x000005f7, 0x00000602, 0x00000610,
+	0x000003b4, 0x000003c8, 0x000003e2, 0x000003f9,
+	0x00000419, 0x00000424, 0x00000439, 0x00000462,
+	0x00000469, 0x0000047a, 0x00000488, 0x000004bc,
+	0x000004f8, 0x00000530, 0x00000546, 0x00000572,
+	0x00000586, 0x000005a5, 0x000005b2, 0x000005b9,
+	0x000005c7, 0x000005d5, 0x000005df, 0x000005eb,
+	0x000005f2, 0x00000600, 0x00000607, 0x0000060e,
 	// Entry 40 - 5F
-	0x00000617, 0x00000622, 0x00000629, 0x00000634,
-	0x00000642, 0x0000064c, 0x000006a6, 0x000006b4,
-	0x000006c9, 0x000006d0, 0x000006de, 0x000006e8,
-	0x000006f9, 0x00000707, 0x00000714, 0x0000071b,
-	0x0000076e, 0x0000077c, 0x00000783, 0x0000078d,
-	0x0000079b, 0x000007a6, 0x000007aa, 0x000007b1,
-	0x000007b8, 0x000007c7, 0x000007d2, 0x000007df,
-	0x000007e6, 0x000007e8, 0x000007f5, 0x0000080a,
+	0x00000619, 0x00000627, 0x0000062e, 0x00000639,
+	0x00000640, 0x0000064b, 0x00000659, 0x00000663,
+	0x000006bd, 0x000006cb, 0x000006e0, 0x000006e7,
+	0x000006f5, 0x000006ff, 0x00000710, 0x0000071e,
+	0x0000072b, 0x00000732, 0x00000785, 0x00000793,
+	0x0000079a, 0x000007a4, 0x000007b2, 0x000007bd,
+	0x000007c1, 0x000007c8, 0x000007cf, 0x000007de,
+	0x000007e9, 0x000007f6, 0x000007fd, 0x000007ff,
 	// Entry 60 - 7F
-	0x00000811, 0x00000826, 0x00000837, 0x0000083e,
-	0x00000845, 0x00000856, 0x00000860, 0x00000878,
-	0x00000886, 0x000008a2, 0x000008ba, 0x000008e0,
-	0x000008ea, 0x000008f4, 0x00000909, 0x00000917,
-	0x00000925, 0x00000941, 0x00000967, 0x0000096e,
-	0x00000986, 0x000009c1, 0x000009e0, 0x00000a17,
-	0x00000a25, 0x00000a3e, 0x00000a4b, 0x00000a52,
-	0x00000a59, 0x00000a63, 0x00000a6e, 0x00000a7c,
+	0x0000080c, 0x00000821, 0x00000828, 0x0000083d,
+	0x0000084e, 0x00000855, 0x0000085c, 0x0000086d,
+	0x00000877, 0x0000088f, 0x0000089d, 0x000008b9,
+	0x000008d1, 0x000008f7, 0x00000901, 0x0000090b,
+	0x00000920, 0x0000092e, 0x0000093c, 0x00000958,
+	0x0000097e, 0x00000985, 0x0000099d, 0x000009d8,
+	0x000009f7, 0x00000a2e, 0x00000a3c, 0x00000a55,
+	0x00000a62, 0x00000a69, 0x00000a70, 0x00000a7a,
 	// Entry 80 - 9F
-	0x00000a8a, 0x00000a98, 0x00000aa9, 0x00000aba,
-	0x00000ac8, 0x00000ad9, 0x00000af4, 0x00000b02,
-	0x00000b12, 0x00000b23, 0x00000b33, 0x00000b3a,
-	0x00000b44, 0x00000b55, 0x00000b63, 0x00000b6d,
-	0x00000b74, 0x00000b83, 0x00000b95, 0x00000ba9,
-	0x00000bb6, 0x00000bca, 0x00000bd6, 0x00000be9,
-	0x00000bf7, 0x00000c33, 0x00000c47, 0x00000c55,
-	0x00000c5c, 0x00000c6e, 0x00000c7c, 0x00000c83,
+	0x00000a85, 0x00000a93, 0x00000aa1, 0x00000aaf,
+	0x00000ac0, 0x00000ad1, 0x00000adf, 0x00000af0,
+	0x00000b0b, 0x00000b19, 0x00000b29, 0x00000b3a,
+	0x00000b4a, 0x00000b51, 0x00000b5b, 0x00000b6c,
+	0x00000b7a, 0x00000b84, 0x00000b8b, 0x00000b9a,
+	0x00000bac, 0x00000bc0, 0x00000bcd, 0x00000be1,
+	0x00000bed, 0x00000c00, 0x00000c0e, 0x00000c4a,
+	0x00000c5e, 0x00000c6c, 0x00000c73, 0x00000c85,
 	// Entry A0 - BF
-	0x00000c91, 0x00000c9f, 0x00000ca6, 0x00000ce4,
-	0x00000d06, 0x00000d40, 0x00000d55, 0x00000d5c,
-	0x00000d70, 0x00000d7a, 0x00000d84, 0x00000d8b,
-	0x00000d92, 0x00000d99, 0x00000da7, 0x00000dae,
-	0x00000db5, 0x00000dbf, 0x00000dc6, 0x00000dda,
-	0x00000de7, 0x00000dee, 0x00000dfc, 0x00000e03,
-	0x00000e1a, 0x00000ed6, 0x00000ef4, 0x00000f08,
-	0x00000f0f, 0x00000f27, 0x00000f73, 0x00000f81,
+	0x00000c93, 0x00000c9a, 0x00000ca8, 0x00000cb6,
+	0x00000cbd, 0x00000cfb, 0x00000d1d, 0x00000d57,
+	0x00000d6c, 0x00000d73, 0x00000d7a, 0x00000d7e,
+	0x00000d89, 0x00000d90, 0x00000d9e, 0x00000da2,
+	0x00000dac, 0x00000dc0, 0x00000dd4, 0x00000dde,
+	0x00000de8, 0x00000def, 0x00000df6, 0x00000dfd,
+	0x00000e0b, 0x00000e12, 0x00000e19, 0x00000e23,
+	0x00000e2a, 0x00000e3e, 0x00000e4b, 0x00000e52,
 	// Entry C0 - DF
-	0x00000f8b, 0x00001003, 0x0000101a, 0x0000103b,
-	0x00001056, 0x0000106d, 0x00001098, 0x000010a6,
-	0x000010b4, 0x000010c2, 0x000010d6, 0x000010e9,
-	0x000010f0, 0x000010fe, 0x0000110c, 0x00001116,
-	0x0000112e, 0x00001147, 0x00001176, 0x00001195,
-	0x000011ca, 0x000011d1, 0x000011e9, 0x000011f7,
-	0x00001240, 0x0000125e, 0x0000126c, 0x00001295,
-	0x000012a2, 0x000012b3, 0x000012fa, 0x00001315,
+	0x00000e60, 0x00000e67, 0x00000e7e, 0x00000f3a,
+	0x00000f58, 0x00000f6c, 0x00000f73, 0x00000f8b,
+	0x00000fd7, 0x00000fe5, 0x00000fef, 0x00001067,
+	0x0000107e, 0x0000109f, 0x000010ba, 0x000010d1,
+	0x000010fc, 0x0000110a, 0x00001118, 0x00001126,
+	0x0000113a, 0x0000114d, 0x00001154, 0x00001162,
+	0x00001170, 0x0000117a, 0x00001192, 0x000011ab,
+	0x000011da, 0x000011f9, 0x0000122e, 0x00001235,
 	// Entry E0 - FF
-	0x00001368, 0x00001379, 0x000013b1, 0x000013eb,
-	0x00001424, 0x00001432, 0x00001465, 0x00001480,
-} // Size: 952 bytes
+	0x0000124d, 0x0000125b, 0x000012a4, 0x000012c2,
+	0x000012d0, 0x000012f9, 0x00001306, 0x00001317,
+	0x0000135e, 0x00001379, 0x000013cc, 0x000013dd,
+	0x00001415, 0x0000144f, 0x00001488, 0x00001496,
+	0x000014c9, 0x000014e4,
+} // Size: 992 bytes
 
-const ko_KRData string = "" + // Size: 5248 bytes
+const ko_KRData string = "" + // Size: 5348 bytes
 	"\x02버전: %[1]s\x02FRP 버전: %[1]s\x02빌드 날짜: %[1]s\x02모든 파일\x02구성 파일\x02인증서 " +
 	"파일\x02열쇠 파일\x02로그 파일\x02허용 범위를 벗어난 숫자\x02%[1]d보다 큰 숫자를 입력하세요.\x02암호 불일" +
 	"치\x02확인하고 다시 시도해 주세요.\x02숫자가 아님\x02유효한 숫자를 입력하세요.\x02새로운 버전!\x02에 대한" +
@@ -764,45 +790,47 @@ const ko_KRData string = "" + // Size: 5248 bytes
 	":\x02FRP 구성 문서를 보려면 FRP 프로젝트 페이지를 방문하십시오:\x02소프트웨어 업데이트를 확인하는 동안 오류가 발생했" +
 	"습니다.\x02현재 사용 가능한 업데이트가 없습니다.\x02확인\x02취소\x02구성\x02새 구성\x02파일에서 구성 가져오" +
 	"기\x02구성이 이미 삭제됨\x02\x22%[1]s\x22 구성이 이미 제거되었습니다.\x02편집하다\x02파일 열기\x02폴" +
-	"더에 표시\x02복사본 생성\x02모두\x02일반 구성만 해당\x02파일에서 가져오기\x02URL에서 가져오기\x02클립보드에" +
-	"서 가져오기\x02공유 링크 복사\x02모든 구성을 ZIP 으로 내보내기\x02삭제\x02구성 만들기\x02수동 설정\x02구" +
-	"성 가져오기\x02%[2]d개 구성 중 %[1]d개를 가져왔습니다.\x02이름이 \x22%[1]s\x22 인 다른 구성이 이미" +
-	" 있습니다.\x02\x22%[1]s\x22 파일은 유효한 ZIP 파일이 아닙니다.\x02\x22%[1]s\x22 구성 삭제\x02" +
-	"\x22%[1]s\x22 구성을 삭제하시겠습니까?\x02새 클라이언트\x02클라이언트 편집 - %[1]s\x02기초적인\x02이름" +
-	"\x02서버 주소\x02서버 포트\x02사용자\x02인증\x02인증 방법\x02없음\x02토큰\x02비밀 키\x02받는 사람" +
-	"\x02범위\x02토큰 URL\x02입증\x02대기 중\x02작동 연결\x02통나무\x02* 로그를 기록하지 않고 원본 로그 파일" +
-	"을 삭제하려면 비워 둡니다.\x02로그 파일\x02로그 파일 선택\x02수준\x02최대 일수\x02관리자\x02관리자 주소" +
-	"\x02관리 포트\x02비밀번호\x02자산\x02관리 서버가 리소스를 로드할 로컬 디렉토리를 선택하십시오.\x02자동 삭제\x02" +
-	"절대\x02상대적\x02날짜 삭제\x02삭제 일\x02날\x02연결\x02규약\x02HTTP 프록시\x02연결 수\x02심장박" +
-	"동\x02간격\x02s\x02타임아웃\x02연결 시간 초과\x02유지\x02유휴 시간 초과\x02최대 스트림\x02켜다\x02" +
-	"폐쇄\x02호스트 이름\x02자격증\x02인증서 파일 선택\x02인증서 키\x02인증서 키 파일 선택\x02신뢰할 수 있는 C" +
-	"A\x02신뢰할 수 있는 CA 파일 선택\x02고급의\x02다중화\x02다중화 대기 중\x02소스 주소\x02다른 옵션\x02로그" +
-	"인 실패 후 종료\x02부팅 시 자동 시작 비활성화\x02관습\x02사용자 지정 옵션\x02* FRP 설정 파일의 [commo" +
-	"n] 부분을 참고하세요.\x02구성이 이미 있습니다.\x02구성 이름 \x22%[1]s\x22 이(가) 이미 존재합니다.\x02새" +
-	" 프록시\x02프록시 편집 - %[1]s\x02무작위의\x02유형\x02역할\x02방문객\x02비밀 키\x02지역 주소\x02로컬" +
-	" 포트\x02원격 포트\x02바인드 주소\x02바인드 포트\x02서버 이름\x02하위 도메인\x02사용자 정의 도메인\x02URL" +
-	" 라우팅\x02멀티플렉서\x02경로 사용자\x02클라이언트\x02서버\x02대역폭\x02프록시 버전\x02비어 있는\x02암호화" +
-	"\x02압축\x02HTTP 사용자\x02HTTP 비밀번호\x02호스트 재작성\x02플러그인\x02플러그인 이름\x02Unix 경로" +
-	"\x02선택 Unix 경로\x02로컬 경로\x02디렉토리 목록에 대한 폴더를 선택하십시오.\x02스트립 접두사\x02부하 분산" +
-	"\x02그룹\x02그룹 비밀 키\x02건강 체크\x02유형\x02시간 초과\x02실패 횟수\x02간격\x02* FRP 에서 지원하" +
-	"는 매개변수를 참조하십시오.\x02프록시가 이미 있습니다.\x02프록시 이름 \x22%[1]s\x22 이(가) 이미 존재합니다" +
-	".\x02로그 폴더 열기\x02최신\x02알려지지 않은\x02달리기\x02중지됨\x02시작\x02멎는\x02상태\x02원격 주소" +
-	"\x02복사\x02시작\x02서비스\x02중지\x02로컬 디렉토리\x02추가하다\x02포트\x02오픈 포트\x02옵션\x02마스터" +
-	" 비밀번호\x02이 프로그램에 대한 액세스를 제한하기 위해 암호를 설정할 수 있습니다.\x0a다음에 이 프로그램을 사용할 때 입력" +
-	"하라는 메시지가 표시됩니다.\x02마스터 비밀번호 사용\x02비밀번호 변경\x02언어\x02현재 표시 언어는\x02수정 사항을" +
-	" 적용하려면 프로그램을 재시작해야 합니다.\x02언어 선택\x02기본값\x02새 구성을 만들 때 기본값을 정의합니다.\x0a여기의" +
-	" 값은 기존 구성에 영향을 주지 않습니다.\x02기본값으로 설정\x02암호가 제거되었습니다.\x02새 마스터 비밀번호\x02비밀번" +
-	"호 재입력\x02비밀번호가 설정되어 있습니다.\x02로그 수준\x02로그 보존\x02빠른 추가\x02원격 데스크탑\x02HTT" +
-	"P 파일 서버\x02켜다\x02구성 열기\x02직접 편집\x02도메인\x02액세스 주소 복사\x02프록시 \x22%[1]s\x22" +
-	" 삭제\x02\x22%[1]s\x22 프록시를 삭제하시겠습니까?\x02프록시 \x22%[1]s\x22 비활성화\x02\x22%[1" +
-	"]s\x22 프록시를 비활성화하시겠습니까?\x02폐쇄\x02패시브 포트 범위\x02FRP 관리자\x02* 한 줄에 하나의 링크로 " +
-	"일괄 가져오기를 지원합니다.\x02자동으로 이름 바꾸기\x02준비가 된\x02올바른 URL 목록을 입력하세요.\x02다운로드" +
-	"\x02암호를 입력\x02%[1]s을(를) 작동하려면 관리 암호를 입력해야 합니다.\x02관리 비밀번호 입력\x02비밀번호가 올바" +
-	"르지 않습니다. 비밀번호를 다시 입력하세요.\x02잘못된 입력\x02%.[1]f에서 %.[2]f까지의 숫자를 입력하세요." +
-	"\x02%[1]s에서 %[2]s 사이의 숫자를 입력하십시오.\x02텍스트가 필수 패턴과 일치하지 않습니다.\x02선택 필수\x02" +
-	"제공된 옵션 중 하나를 선택하십시오.\x02선택이 필요합니다."
+	"더에 표시\x02복사본 생성\x02모두\x02일반 구성만 해당\x02구성 가져오기\x02파일에서 가져오기\x02URL에서 가져" +
+	"오기\x02클립보드에서 가져오기\x02NAT 검색\x02공유 링크 복사\x02모든 구성을 ZIP 으로 내보내기\x02삭제" +
+	"\x02구성 만들기\x02수동 설정\x02%[2]d개 구성 중 %[1]d개를 가져왔습니다.\x02이름이 \x22%[1]s\x22 " +
+	"인 다른 구성이 이미 있습니다.\x02\x22%[1]s\x22 파일은 유효한 ZIP 파일이 아닙니다.\x02\x22%[1]s" +
+	"\x22 구성 삭제\x02\x22%[1]s\x22 구성을 삭제하시겠습니까?\x02새 클라이언트\x02클라이언트 편집 - %[1]s" +
+	"\x02기초적인\x02이름\x02서버 주소\x02서버 포트\x02사용자\x02STUN 서버\x02인증\x02인증 방법\x02없음" +
+	"\x02토큰\x02비밀 키\x02받는 사람\x02범위\x02토큰 URL\x02입증\x02대기 중\x02작동 연결\x02통나무" +
+	"\x02* 로그를 기록하지 않고 원본 로그 파일을 삭제하려면 비워 둡니다.\x02로그 파일\x02로그 파일 선택\x02수준\x02" +
+	"최대 일수\x02관리자\x02관리자 주소\x02관리 포트\x02비밀번호\x02자산\x02관리 서버가 리소스를 로드할 로컬 디렉" +
+	"토리를 선택하십시오.\x02자동 삭제\x02절대\x02상대적\x02날짜 삭제\x02삭제 일\x02날\x02연결\x02규약" +
+	"\x02HTTP 프록시\x02연결 수\x02심장박동\x02간격\x02s\x02타임아웃\x02연결 시간 초과\x02유지\x02유휴 " +
+	"시간 초과\x02최대 스트림\x02켜다\x02폐쇄\x02호스트 이름\x02자격증\x02인증서 파일 선택\x02인증서 키\x02" +
+	"인증서 키 파일 선택\x02신뢰할 수 있는 CA\x02신뢰할 수 있는 CA 파일 선택\x02고급의\x02다중화\x02다중화 대" +
+	"기 중\x02소스 주소\x02다른 옵션\x02로그인 실패 후 종료\x02부팅 시 자동 시작 비활성화\x02관습\x02사용자 지" +
+	"정 옵션\x02* FRP 설정 파일의 [common] 부분을 참고하세요.\x02구성이 이미 있습니다.\x02구성 이름 \x22" +
+	"%[1]s\x22 이(가) 이미 존재합니다.\x02새 프록시\x02프록시 편집 - %[1]s\x02무작위의\x02유형\x02역할" +
+	"\x02방문객\x02비밀 키\x02지역 주소\x02로컬 포트\x02원격 포트\x02바인드 주소\x02바인드 포트\x02서버 이름" +
+	"\x02하위 도메인\x02사용자 정의 도메인\x02URL 라우팅\x02멀티플렉서\x02경로 사용자\x02클라이언트\x02서버" +
+	"\x02대역폭\x02프록시 버전\x02비어 있는\x02암호화\x02압축\x02HTTP 사용자\x02HTTP 비밀번호\x02호스트 " +
+	"재작성\x02플러그인\x02플러그인 이름\x02Unix 경로\x02선택 Unix 경로\x02로컬 경로\x02디렉토리 목록에 대" +
+	"한 폴더를 선택하십시오.\x02스트립 접두사\x02부하 분산\x02그룹\x02그룹 비밀 키\x02건강 체크\x02유형\x02시" +
+	"간 초과\x02실패 횟수\x02간격\x02* FRP 에서 지원하는 매개변수를 참조하십시오.\x02프록시가 이미 있습니다." +
+	"\x02프록시 이름 \x22%[1]s\x22 이(가) 이미 존재합니다.\x02로그 폴더 열기\x02최신\x02안건\x02값\x02" +
+	"NAT 유형\x02행실\x02외부 주소\x02예\x02아니요\x02공용 네트워크\x02알려지지 않은\x02달리기\x02중지됨" +
+	"\x02시작\x02멎는\x02상태\x02원격 주소\x02복사\x02시작\x02서비스\x02중지\x02로컬 디렉토리\x02추가하다" +
+	"\x02포트\x02오픈 포트\x02옵션\x02마스터 비밀번호\x02이 프로그램에 대한 액세스를 제한하기 위해 암호를 설정할 수 있" +
+	"습니다.\x0a다음에 이 프로그램을 사용할 때 입력하라는 메시지가 표시됩니다.\x02마스터 비밀번호 사용\x02비밀번호 변경" +
+	"\x02언어\x02현재 표시 언어는\x02수정 사항을 적용하려면 프로그램을 재시작해야 합니다.\x02언어 선택\x02기본값\x02" +
+	"새 구성을 만들 때 기본값을 정의합니다.\x0a여기의 값은 기존 구성에 영향을 주지 않습니다.\x02기본값으로 설정\x02암호" +
+	"가 제거되었습니다.\x02새 마스터 비밀번호\x02비밀번호 재입력\x02비밀번호가 설정되어 있습니다.\x02로그 수준\x02로" +
+	"그 보존\x02빠른 추가\x02원격 데스크탑\x02HTTP 파일 서버\x02켜다\x02구성 열기\x02직접 편집\x02도메인" +
+	"\x02액세스 주소 복사\x02프록시 \x22%[1]s\x22 삭제\x02\x22%[1]s\x22 프록시를 삭제하시겠습니까?" +
+	"\x02프록시 \x22%[1]s\x22 비활성화\x02\x22%[1]s\x22 프록시를 비활성화하시겠습니까?\x02폐쇄\x02패시" +
+	"브 포트 범위\x02FRP 관리자\x02* 한 줄에 하나의 링크로 일괄 가져오기를 지원합니다.\x02자동으로 이름 바꾸기" +
+	"\x02준비가 된\x02올바른 URL 목록을 입력하세요.\x02다운로드\x02암호를 입력\x02%[1]s을(를) 작동하려면 관리 " +
+	"암호를 입력해야 합니다.\x02관리 비밀번호 입력\x02비밀번호가 올바르지 않습니다. 비밀번호를 다시 입력하세요.\x02잘못된" +
+	" 입력\x02%.[1]f에서 %.[2]f까지의 숫자를 입력하세요.\x02%[1]s에서 %[2]s 사이의 숫자를 입력하십시오." +
+	"\x02텍스트가 필수 패턴과 일치하지 않습니다.\x02선택 필수\x02제공된 옵션 중 하나를 선택하십시오.\x02선택이 필요합니다" +
+	"."
 
-var zh_CNIndex = []uint32{ // 232 elements
+var zh_CNIndex = []uint32{ // 242 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000f, 0x00000022, 0x00000037,
 	0x00000044, 0x00000051, 0x0000005e, 0x0000006b,
@@ -814,88 +842,92 @@ var zh_CNIndex = []uint32{ // 232 elements
 	0x00000244, 0x00000254, 0x00000275, 0x0000027c,
 	// Entry 20 - 3F
 	0x00000289, 0x0000029f, 0x000002ac, 0x000002b3,
-	0x000002c3, 0x000002d3, 0x000002e2, 0x000002f5,
-	0x00000308, 0x0000032b, 0x00000332, 0x0000033f,
-	0x0000034c, 0x00000359, 0x0000038c, 0x000003bc,
-	0x000003ea, 0x00000402, 0x00000441, 0x00000451,
-	0x00000469, 0x00000470, 0x00000477, 0x00000487,
-	0x00000497, 0x000004a1, 0x000004a8, 0x000004b5,
-	0x000004b9, 0x000004c0, 0x000004c7, 0x000004d1,
+	0x000002c3, 0x000002d0, 0x000002e0, 0x000002ef,
+	0x00000302, 0x0000030d, 0x00000320, 0x00000343,
+	0x0000034a, 0x00000357, 0x00000364, 0x00000397,
+	0x000003c7, 0x000003f5, 0x0000040d, 0x0000044c,
+	0x0000045c, 0x00000474, 0x0000047b, 0x00000482,
+	0x00000492, 0x000004a2, 0x000004ac, 0x000004b8,
+	0x000004bf, 0x000004cc, 0x000004d0, 0x000004d7,
 	// Entry 40 - 5F
-	0x000004db, 0x000004e8, 0x000004ef, 0x000004fc,
-	0x00000509, 0x00000510, 0x0000054f, 0x0000055c,
-	0x0000056f, 0x00000576, 0x00000583, 0x0000058a,
-	0x00000597, 0x000005a4, 0x000005ab, 0x000005b8,
-	0x000005ec, 0x000005f9, 0x00000600, 0x00000607,
-	0x00000614, 0x00000621, 0x00000625, 0x0000062c,
-	0x00000633, 0x0000063f, 0x0000064f, 0x00000656,
-	0x0000065d, 0x00000661, 0x00000668, 0x00000675,
+	0x000004de, 0x000004e8, 0x000004f2, 0x000004ff,
+	0x00000506, 0x00000513, 0x00000520, 0x00000527,
+	0x00000566, 0x00000573, 0x00000586, 0x0000058d,
+	0x0000059a, 0x000005a1, 0x000005ae, 0x000005bb,
+	0x000005c2, 0x000005cf, 0x00000603, 0x00000610,
+	0x00000617, 0x0000061e, 0x0000062b, 0x00000638,
+	0x0000063c, 0x00000643, 0x0000064a, 0x00000656,
+	0x00000666, 0x0000066d, 0x00000674, 0x00000678,
 	// Entry 60 - 7F
-	0x00000682, 0x0000068f, 0x0000069f, 0x000006a6,
-	0x000006ad, 0x000006ba, 0x000006c7, 0x000006da,
-	0x000006e7, 0x00000700, 0x00000710, 0x00000729,
-	0x00000730, 0x0000073d, 0x0000074d, 0x0000075d,
-	0x0000076a, 0x00000786, 0x0000079c, 0x000007a6,
-	0x000007b6, 0x000007e6, 0x000007f6, 0x00000817,
-	0x00000824, 0x00000839, 0x00000846, 0x0000084d,
-	0x00000854, 0x0000085e, 0x00000865, 0x00000872,
+	0x0000067f, 0x0000068c, 0x00000699, 0x000006a6,
+	0x000006b6, 0x000006bd, 0x000006c4, 0x000006d1,
+	0x000006de, 0x000006f1, 0x000006fe, 0x00000717,
+	0x00000727, 0x00000740, 0x00000747, 0x00000754,
+	0x00000764, 0x00000774, 0x00000781, 0x0000079d,
+	0x000007b3, 0x000007bd, 0x000007cd, 0x000007fd,
+	0x0000080d, 0x0000082e, 0x0000083b, 0x00000850,
+	0x0000085d, 0x00000864, 0x0000086b, 0x00000875,
 	// Entry 80 - 9F
-	0x0000087f, 0x0000088c, 0x00000899, 0x000008a6,
-	0x000008b3, 0x000008bd, 0x000008cd, 0x000008d8,
-	0x000008e2, 0x000008ef, 0x000008f9, 0x00000903,
-	0x00000910, 0x0000091d, 0x00000921, 0x0000092e,
-	0x0000093b, 0x00000947, 0x00000953, 0x0000095f,
-	0x00000966, 0x00000973, 0x0000097f, 0x00000992,
-	0x0000099f, 0x000009cd, 0x000009da, 0x000009e7,
-	0x000009f4, 0x00000a01, 0x00000a0e, 0x00000a1b,
+	0x0000087c, 0x00000889, 0x00000896, 0x000008a3,
+	0x000008b0, 0x000008bd, 0x000008ca, 0x000008d4,
+	0x000008e4, 0x000008ef, 0x000008f9, 0x00000906,
+	0x00000910, 0x0000091a, 0x00000927, 0x00000934,
+	0x00000938, 0x00000945, 0x00000952, 0x0000095e,
+	0x0000096a, 0x00000976, 0x0000097d, 0x0000098a,
+	0x00000996, 0x000009a9, 0x000009b6, 0x000009e4,
+	0x000009f1, 0x000009fe, 0x00000a0b, 0x00000a18,
 	// Entry A0 - BF
-	0x00000a28, 0x00000a35, 0x00000a42, 0x00000a62,
-	0x00000a72, 0x00000a93, 0x00000aa9, 0x00000ab0,
-	0x00000ab7, 0x00000ac4, 0x00000ace, 0x00000adb,
-	0x00000ae8, 0x00000aef, 0x00000afc, 0x00000b03,
-	0x00000b0a, 0x00000b11, 0x00000b18, 0x00000b25,
-	0x00000b2c, 0x00000b33, 0x00000b40, 0x00000b47,
-	0x00000b51, 0x00000bbf, 0x00000bcf, 0x00000bdc,
-	0x00000be3, 0x00000bf9, 0x00000c2a, 0x00000c37,
+	0x00000a25, 0x00000a32, 0x00000a3f, 0x00000a4c,
+	0x00000a59, 0x00000a79, 0x00000a89, 0x00000aaa,
+	0x00000ac0, 0x00000ac7, 0x00000ace, 0x00000ad2,
+	0x00000add, 0x00000ae4, 0x00000af1, 0x00000af5,
+	0x00000af9, 0x00000b00, 0x00000b07, 0x00000b14,
+	0x00000b1e, 0x00000b2b, 0x00000b38, 0x00000b3f,
+	0x00000b4c, 0x00000b53, 0x00000b5a, 0x00000b61,
+	0x00000b68, 0x00000b75, 0x00000b7c, 0x00000b83,
 	// Entry C0 - DF
-	0x00000c41, 0x00000c91, 0x00000ca1, 0x00000cb4,
-	0x00000cc1, 0x00000cce, 0x00000ce1, 0x00000cee,
-	0x00000cfb, 0x00000d08, 0x00000d15, 0x00000d27,
-	0x00000d2e, 0x00000d41, 0x00000d4e, 0x00000d55,
-	0x00000d68, 0x00000d80, 0x00000da7, 0x00000dbf,
-	0x00000de6, 0x00000ded, 0x00000e00, 0x00000e0e,
-	0x00000e3b, 0x00000e4b, 0x00000e58, 0x00000e79,
-	0x00000e80, 0x00000e8d, 0x00000ebb, 0x00000ece,
+	0x00000b90, 0x00000b97, 0x00000ba1, 0x00000c0f,
+	0x00000c1f, 0x00000c2c, 0x00000c33, 0x00000c49,
+	0x00000c7a, 0x00000c87, 0x00000c91, 0x00000ce1,
+	0x00000cf1, 0x00000d04, 0x00000d11, 0x00000d1e,
+	0x00000d31, 0x00000d3e, 0x00000d4b, 0x00000d58,
+	0x00000d65, 0x00000d77, 0x00000d7e, 0x00000d91,
+	0x00000d9e, 0x00000da5, 0x00000db8, 0x00000dd0,
+	0x00000df7, 0x00000e0f, 0x00000e36, 0x00000e3d,
 	// Entry E0 - FF
-	0x00000ef0, 0x00000efd, 0x00000f2f, 0x00000f5f,
-	0x00000f84, 0x00000f8e, 0x00000fad, 0x00000fbd,
-} // Size: 952 bytes
+	0x00000e50, 0x00000e5e, 0x00000e8b, 0x00000e9b,
+	0x00000ea8, 0x00000ec9, 0x00000ed0, 0x00000edd,
+	0x00000f0b, 0x00000f1e, 0x00000f40, 0x00000f4d,
+	0x00000f7f, 0x00000faf, 0x00000fd4, 0x00000fde,
+	0x00000ffd, 0x0000100d,
+} // Size: 992 bytes
 
-const zh_CNData string = "" + // Size: 4029 bytes
+const zh_CNData string = "" + // Size: 4109 bytes
 	"\x02版本：%[1]s\x02FRP 版本：%[1]s\x02构建日期：%[1]s\x02所有文件\x02配置文件\x02证书文件\x02密钥" +
 	"文件\x02日志文件\x02数值超出允许范围\x02请输入一个大于 %[1]d 的数字。\x02密码不匹配\x02请检查并重试。\x02不是" +
 	"数字\x02请输入一个有效的数字。\x02发现更新！\x02关于\x02下载更新\x02正在检查更新\x02检查更新\x02如有任何意见或报" +
 	"告错误，请访问项目地址：\x02了解 FRP 软件配置文档，请访问 FRP 项目地址：\x02检查更新时出现错误。\x02当前没有可用的更新" +
 	"。\x02确定\x02取消\x02配置\x02新建配置\x02从文件导入配置\x02配置已删除\x02配置名「%[1]s」已删除。\x02编" +
-	"辑\x02打开文件\x02在文件夹中显示\x02创建副本\x02全部\x02仅通用配置\x02从文件导入\x02从 URL 导入\x02从剪" +
-	"贴板导入\x02复制分享链接\x02导出所有配置 (ZIP 压缩包)\x02删除\x02新建配置\x02手动设置\x02导入配置\x02导入" +
-	"了 %[2]d 个配置文件中的 %[1]d 个。\x02另一个同名的配置「%[1]s」已存在。\x02文件 \x22%[1]s\x22 不是" +
-	"有效的压缩文件。\x02删除配置「%[1]s」\x02确定要删除配置「%[1]s」吗？此操作无法撤销。\x02新建客户端\x02编辑客户端 " +
-	"- %[1]s\x02基本\x02名称\x02服务器地址\x02服务器端口\x02用户名\x02认证\x02认证方式\x02无\x02令牌" +
-	"\x02密钥\x02接收者\x02作用域\x02令牌地址\x02鉴权\x02心跳消息\x02工作连接\x02日志\x02* 留空则不记录日志，且" +
-	"删除原来的日志文件。\x02日志文件\x02选择日志文件\x02级别\x02最大天数\x02管理\x02管理地址\x02管理端口\x02密码" +
-	"\x02静态资源\x02选择管理服务器使用的静态资源目录。\x02自动删除\x02绝对\x02相对\x02删除日期\x02删除天数\x02天" +
-	"\x02连接\x02协议\x02HTTP 代理\x02连接池数量\x02心跳\x02间隔\x02秒\x02超时\x02连接超时\x02保活周期" +
-	"\x02闲置超时\x02最大流数量\x02开启\x02关闭\x02主机名称\x02证书文件\x02选择证书文件\x02密钥文件\x02选择证书密" +
-	"钥文件\x02受信任证书\x02选择受信任的证书\x02高级\x02多路复用\x02复用器心跳\x02使用源地址\x02其他选项\x02初次" +
-	"登录失败后退出\x02禁用开机自启动\x02自定义\x02自定义参数\x02* 参考 FRP 配置文件的 [common] 部分。\x02配" +
-	"置已存在\x02配置名「%[1]s」已存在。\x02新建代理\x02编辑代理 - %[1]s\x02随机名称\x02类型\x02角色\x02" +
-	"访问者\x02私钥\x02本地地址\x02本地端口\x02远程端口\x02绑定地址\x02绑定端口\x02服务名称\x02子域名\x02自定" +
-	"义域名\x02URL 路由\x02复用器\x02路由用户\x02客户端\x02服务端\x02带宽限流\x02代理版本\x02空\x02加密传" +
-	"输\x02压缩传输\x02HTTP 用户\x02HTTP 密码\x02Host 替换\x02插件\x02插件名称\x02Unix 路径" +
-	"\x02选择 Unix 路径\x02本地路径\x02选择需要显示目录列表的文件夹。\x02移除前缀\x02负载均衡\x02分组名称\x02分组密" +
-	"钥\x02健康检查\x02检查类型\x02检查超时\x02错误次数\x02检查周期\x02* 参考 FRP 支持的参数。\x02代理已存在" +
-	"\x02代理名「%[1]s」已存在。\x02打开日志文件夹\x02最新\x02未知\x02正在运行\x02已停止\x02正在启动\x02正在停止" +
+	"辑\x02打开文件\x02在文件夹中显示\x02创建副本\x02全部\x02仅通用配置\x02导入配置\x02从文件导入\x02从 URL " +
+	"导入\x02从剪贴板导入\x02NAT 检测\x02复制分享链接\x02导出所有配置 (ZIP 压缩包)\x02删除\x02新建配置\x02" +
+	"手动设置\x02导入了 %[2]d 个配置文件中的 %[1]d 个。\x02另一个同名的配置「%[1]s」已存在。\x02文件 \x22%[" +
+	"1]s\x22 不是有效的压缩文件。\x02删除配置「%[1]s」\x02确定要删除配置「%[1]s」吗？此操作无法撤销。\x02新建客户端" +
+	"\x02编辑客户端 - %[1]s\x02基本\x02名称\x02服务器地址\x02服务器端口\x02用户名\x02STUN 服务\x02认证" +
+	"\x02认证方式\x02无\x02令牌\x02密钥\x02接收者\x02作用域\x02令牌地址\x02鉴权\x02心跳消息\x02工作连接" +
+	"\x02日志\x02* 留空则不记录日志，且删除原来的日志文件。\x02日志文件\x02选择日志文件\x02级别\x02最大天数\x02管理" +
+	"\x02管理地址\x02管理端口\x02密码\x02静态资源\x02选择管理服务器使用的静态资源目录。\x02自动删除\x02绝对\x02相对" +
+	"\x02删除日期\x02删除天数\x02天\x02连接\x02协议\x02HTTP 代理\x02连接池数量\x02心跳\x02间隔\x02秒" +
+	"\x02超时\x02连接超时\x02保活周期\x02闲置超时\x02最大流数量\x02开启\x02关闭\x02主机名称\x02证书文件\x02选" +
+	"择证书文件\x02密钥文件\x02选择证书密钥文件\x02受信任证书\x02选择受信任的证书\x02高级\x02多路复用\x02复用器心跳" +
+	"\x02使用源地址\x02其他选项\x02初次登录失败后退出\x02禁用开机自启动\x02自定义\x02自定义参数\x02* 参考 FRP 配置" +
+	"文件的 [common] 部分。\x02配置已存在\x02配置名「%[1]s」已存在。\x02新建代理\x02编辑代理 - %[1]s" +
+	"\x02随机名称\x02类型\x02角色\x02访问者\x02私钥\x02本地地址\x02本地端口\x02远程端口\x02绑定地址\x02绑定端" +
+	"口\x02服务名称\x02子域名\x02自定义域名\x02URL 路由\x02复用器\x02路由用户\x02客户端\x02服务端\x02带宽" +
+	"限流\x02代理版本\x02空\x02加密传输\x02压缩传输\x02HTTP 用户\x02HTTP 密码\x02Host 替换\x02插件" +
+	"\x02插件名称\x02Unix 路径\x02选择 Unix 路径\x02本地路径\x02选择需要显示目录列表的文件夹。\x02移除前缀\x02" +
+	"负载均衡\x02分组名称\x02分组密钥\x02健康检查\x02检查类型\x02检查超时\x02错误次数\x02检查周期\x02* 参考 F" +
+	"RP 支持的参数。\x02代理已存在\x02代理名「%[1]s」已存在。\x02打开日志文件夹\x02最新\x02项目\x02值\x02NAT " +
+	"类型\x02行为\x02外部地址\x02是\x02否\x02公网\x02未知\x02正在运行\x02已停止\x02正在启动\x02正在停止" +
 	"\x02状态\x02远程地址\x02复制\x02启动\x02服务\x02停止\x02本地目录\x02添加\x02端口\x02打开端口\x02选项" +
 	"\x02主密码\x02您可以设置密码来限制访问此程序。\x0a在下次使用此程序时，您将被要求输入密码。\x02使用主密码\x02修改密码\x02" +
 	"语言\x02目前的显示语言\x02您必须重新启动程序才能应用修改。\x02选择语言\x02默认值\x02定义新建配置时的默认值。\x0a此处" +
@@ -907,7 +939,7 @@ const zh_CNData string = "" + // Size: 4029 bytes
 	"请重新输入。\x02输入无效\x02请输入一个从 %.[1]f 到 %.[2]f 的数字。\x02请输入一个从 %[1]s 到 %[2]s " +
 	"的数字。\x02文本与要求的模式不匹配。\x02必填项\x02请选择其中一个选项。\x02需要选择。"
 
-var zh_TWIndex = []uint32{ // 232 elements
+var zh_TWIndex = []uint32{ // 242 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000f, 0x00000022, 0x00000037,
 	0x00000044, 0x00000051, 0x0000005e, 0x0000006b,
@@ -919,88 +951,92 @@ var zh_TWIndex = []uint32{ // 232 elements
 	0x00000244, 0x00000254, 0x00000275, 0x0000027c,
 	// Entry 20 - 3F
 	0x00000289, 0x0000029f, 0x000002ac, 0x000002b3,
-	0x000002c3, 0x000002d3, 0x000002e2, 0x000002f5,
-	0x00000308, 0x0000032b, 0x00000332, 0x0000033f,
-	0x0000034c, 0x00000359, 0x0000038c, 0x000003bc,
-	0x000003ea, 0x00000402, 0x00000441, 0x00000451,
-	0x00000469, 0x00000470, 0x00000477, 0x00000487,
-	0x00000497, 0x000004a1, 0x000004a8, 0x000004b5,
-	0x000004b9, 0x000004c0, 0x000004c7, 0x000004d1,
+	0x000002c3, 0x000002d0, 0x000002e0, 0x000002ef,
+	0x00000302, 0x0000030d, 0x00000320, 0x00000343,
+	0x0000034a, 0x00000357, 0x00000364, 0x00000397,
+	0x000003c7, 0x000003f5, 0x0000040d, 0x0000044c,
+	0x0000045c, 0x00000474, 0x0000047b, 0x00000482,
+	0x00000492, 0x000004a2, 0x000004ac, 0x000004b8,
+	0x000004bf, 0x000004cc, 0x000004d0, 0x000004d7,
 	// Entry 40 - 5F
-	0x000004db, 0x000004e8, 0x000004ef, 0x000004fc,
-	0x00000509, 0x00000510, 0x0000054f, 0x0000055c,
-	0x0000056f, 0x00000576, 0x00000583, 0x0000058a,
-	0x00000597, 0x000005a4, 0x000005ab, 0x000005b8,
-	0x000005ec, 0x000005f9, 0x00000600, 0x00000607,
-	0x00000614, 0x00000621, 0x00000625, 0x0000062c,
-	0x00000633, 0x0000063f, 0x0000064f, 0x00000656,
-	0x0000065d, 0x00000661, 0x00000668, 0x00000675,
+	0x000004de, 0x000004e8, 0x000004f2, 0x000004ff,
+	0x00000506, 0x00000513, 0x00000520, 0x00000527,
+	0x00000566, 0x00000573, 0x00000586, 0x0000058d,
+	0x0000059a, 0x000005a1, 0x000005ae, 0x000005bb,
+	0x000005c2, 0x000005cf, 0x00000603, 0x00000610,
+	0x00000617, 0x0000061e, 0x0000062b, 0x00000638,
+	0x0000063c, 0x00000643, 0x0000064a, 0x00000656,
+	0x00000666, 0x0000066d, 0x00000674, 0x00000678,
 	// Entry 60 - 7F
-	0x00000682, 0x0000068f, 0x0000069f, 0x000006a6,
-	0x000006ad, 0x000006ba, 0x000006c7, 0x000006da,
-	0x000006e7, 0x00000700, 0x00000710, 0x00000729,
-	0x00000730, 0x0000073d, 0x0000074d, 0x0000075d,
-	0x0000076a, 0x00000786, 0x0000079c, 0x000007a6,
-	0x000007b6, 0x000007e6, 0x000007f6, 0x00000817,
-	0x00000824, 0x00000839, 0x00000846, 0x0000084d,
-	0x00000854, 0x0000085e, 0x00000865, 0x00000872,
+	0x0000067f, 0x0000068c, 0x00000699, 0x000006a6,
+	0x000006b6, 0x000006bd, 0x000006c4, 0x000006d1,
+	0x000006de, 0x000006f1, 0x000006fe, 0x00000717,
+	0x00000727, 0x00000740, 0x00000747, 0x00000754,
+	0x00000764, 0x00000774, 0x00000781, 0x0000079d,
+	0x000007b3, 0x000007bd, 0x000007cd, 0x000007fd,
+	0x0000080d, 0x0000082e, 0x0000083b, 0x00000850,
+	0x0000085d, 0x00000864, 0x0000086b, 0x00000875,
 	// Entry 80 - 9F
-	0x0000087f, 0x0000088c, 0x00000899, 0x000008a6,
-	0x000008b3, 0x000008bd, 0x000008cd, 0x000008d8,
-	0x000008e2, 0x000008ef, 0x000008f9, 0x00000903,
-	0x00000910, 0x0000091d, 0x00000921, 0x0000092e,
-	0x0000093b, 0x00000947, 0x00000953, 0x0000095f,
-	0x00000966, 0x00000973, 0x0000097f, 0x00000992,
-	0x0000099f, 0x000009cd, 0x000009da, 0x000009e7,
-	0x000009f4, 0x00000a01, 0x00000a0e, 0x00000a1b,
+	0x0000087c, 0x00000889, 0x00000896, 0x000008a3,
+	0x000008b0, 0x000008bd, 0x000008ca, 0x000008d4,
+	0x000008e4, 0x000008ef, 0x000008f9, 0x00000906,
+	0x00000910, 0x0000091a, 0x00000927, 0x00000934,
+	0x00000938, 0x00000945, 0x00000952, 0x0000095e,
+	0x0000096a, 0x00000976, 0x0000097d, 0x0000098a,
+	0x00000996, 0x000009a9, 0x000009b6, 0x000009e4,
+	0x000009f1, 0x000009fe, 0x00000a0b, 0x00000a18,
 	// Entry A0 - BF
-	0x00000a28, 0x00000a35, 0x00000a42, 0x00000a62,
-	0x00000a72, 0x00000a93, 0x00000aa9, 0x00000ab0,
-	0x00000ab7, 0x00000ac4, 0x00000ace, 0x00000adb,
-	0x00000ae8, 0x00000aef, 0x00000afc, 0x00000b03,
-	0x00000b0a, 0x00000b11, 0x00000b18, 0x00000b25,
-	0x00000b2c, 0x00000b33, 0x00000b40, 0x00000b47,
-	0x00000b51, 0x00000bbf, 0x00000bcf, 0x00000bdc,
-	0x00000be3, 0x00000bf9, 0x00000c2a, 0x00000c37,
+	0x00000a25, 0x00000a32, 0x00000a3f, 0x00000a4c,
+	0x00000a59, 0x00000a79, 0x00000a89, 0x00000aaa,
+	0x00000ac0, 0x00000ac7, 0x00000ace, 0x00000ad2,
+	0x00000add, 0x00000ae4, 0x00000af1, 0x00000af5,
+	0x00000af9, 0x00000b00, 0x00000b07, 0x00000b14,
+	0x00000b1e, 0x00000b2b, 0x00000b38, 0x00000b3f,
+	0x00000b4c, 0x00000b53, 0x00000b5a, 0x00000b61,
+	0x00000b68, 0x00000b75, 0x00000b7c, 0x00000b83,
 	// Entry C0 - DF
-	0x00000c41, 0x00000c91, 0x00000ca1, 0x00000cb4,
-	0x00000cc1, 0x00000cce, 0x00000ce1, 0x00000cee,
-	0x00000cfb, 0x00000d08, 0x00000d15, 0x00000d27,
-	0x00000d2e, 0x00000d41, 0x00000d4e, 0x00000d55,
-	0x00000d68, 0x00000d80, 0x00000da7, 0x00000dbf,
-	0x00000de6, 0x00000ded, 0x00000e00, 0x00000e0e,
-	0x00000e3b, 0x00000e4b, 0x00000e58, 0x00000e79,
-	0x00000e80, 0x00000e8d, 0x00000ebb, 0x00000ece,
+	0x00000b90, 0x00000b97, 0x00000ba1, 0x00000c0f,
+	0x00000c1f, 0x00000c2c, 0x00000c33, 0x00000c49,
+	0x00000c7a, 0x00000c87, 0x00000c91, 0x00000ce1,
+	0x00000cf1, 0x00000d04, 0x00000d11, 0x00000d1e,
+	0x00000d31, 0x00000d3e, 0x00000d4b, 0x00000d58,
+	0x00000d65, 0x00000d77, 0x00000d7e, 0x00000d91,
+	0x00000d9e, 0x00000da5, 0x00000db8, 0x00000dd0,
+	0x00000df7, 0x00000e0f, 0x00000e36, 0x00000e3d,
 	// Entry E0 - FF
-	0x00000ef0, 0x00000efd, 0x00000f2f, 0x00000f5f,
-	0x00000f84, 0x00000f8e, 0x00000fad, 0x00000fbd,
-} // Size: 952 bytes
+	0x00000e50, 0x00000e5e, 0x00000e8b, 0x00000e9b,
+	0x00000ea8, 0x00000ec9, 0x00000ed0, 0x00000edd,
+	0x00000f0b, 0x00000f1e, 0x00000f40, 0x00000f4d,
+	0x00000f7f, 0x00000faf, 0x00000fd4, 0x00000fde,
+	0x00000ffd, 0x0000100d,
+} // Size: 992 bytes
 
-const zh_TWData string = "" + // Size: 4029 bytes
+const zh_TWData string = "" + // Size: 4109 bytes
 	"\x02版本：%[1]s\x02FRP 版本：%[1]s\x02構建日期：%[1]s\x02所有文件\x02配置文件\x02證書文件\x02密鑰" +
 	"文件\x02日誌文件\x02數值超出允許範圍\x02請輸入一個大於 %[1]d 的數字。\x02密碼不匹配\x02請檢查並重試。\x02不是" +
 	"數字\x02請輸入一個有效的數字。\x02發現更新！\x02關於\x02下載更新\x02正在檢查更新\x02檢查更新\x02如有任何意見或報" +
 	"告錯誤，請訪問項目地址：\x02了解 FRP 軟件配置文檔，請訪問 FRP 項目地址：\x02檢查更新時出現錯誤。\x02當前沒有可用的更新" +
 	"。\x02確定\x02取消\x02配置\x02新建配置\x02從文件導入配置\x02配置已刪除\x02配置名「%[1]s」已刪除。\x02編" +
-	"輯\x02打開文件\x02在文件夾中顯示\x02創建副本\x02全部\x02僅通用配置\x02從文件導入\x02從 URL 導入\x02從剪" +
-	"貼板導入\x02復制分享鏈接\x02導出所有配置 (ZIP 壓縮包)\x02刪除\x02新建配置\x02手動設置\x02導入配置\x02導入" +
-	"了 %[2]d 個配置文件中的 %[1]d 個。\x02另一個同名的配置「%[1]s」已存在。\x02文件 \x22%[1]s\x22 不是" +
-	"有效的壓縮文件。\x02刪除配置「%[1]s」\x02確定要刪除配置「%[1]s」嗎？此操作無法撤銷。\x02新建客戶端\x02編輯客戶端 " +
-	"- %[1]s\x02基本\x02名稱\x02服務器地址\x02服務器端口\x02用戶名\x02認證\x02認證方式\x02無\x02令牌" +
-	"\x02密鑰\x02接收者\x02作用域\x02令牌地址\x02鑑權\x02心跳消息\x02工作連接\x02日誌\x02* 留空則不記錄日誌，且" +
-	"刪除原來的日誌文件。\x02日誌文件\x02選擇日誌文件\x02級別\x02最大天數\x02管理\x02管理地址\x02管理端口\x02密碼" +
-	"\x02靜態資源\x02選擇管理服務器使用的靜態資源目錄。\x02自動刪除\x02絕對\x02相對\x02刪除日期\x02刪除天數\x02天" +
-	"\x02連接\x02協議\x02HTTP 代理\x02連接池數量\x02心跳\x02間隔\x02秒\x02超時\x02連接超時\x02保活週期" +
-	"\x02閒置超時\x02最大流數量\x02開啟\x02關閉\x02主機名稱\x02證書文件\x02選擇證書文件\x02密鑰文件\x02選擇證書密" +
-	"鑰文件\x02受信任證書\x02選擇受信任的證書\x02高級\x02多路復用\x02復用器心跳\x02使用源地址\x02其他選項\x02初次" +
-	"登錄失敗後退出\x02禁用開機自啟動\x02自定義\x02自定義參數\x02* 參考 FRP 配置文件的 [common] 部分。\x02配" +
-	"置已存在\x02配置名「%[1]s」已存在。\x02新建代理\x02編輯代理 - %[1]s\x02隨機名稱\x02類型\x02角色\x02" +
-	"訪問者\x02私鑰\x02本地地址\x02本地端口\x02遠程端口\x02綁定地址\x02綁定端口\x02服務名稱\x02子域名\x02自定" +
-	"義域名\x02URL 路由\x02復用器\x02路由用戶\x02客戶端\x02服務端\x02帶寬限流\x02代理版本\x02空\x02加密傳" +
-	"輸\x02壓縮傳輸\x02HTTP 用戶\x02HTTP 密碼\x02Host 替換\x02插件\x02插件名稱\x02Unix 路徑" +
-	"\x02選擇 Unix 路徑\x02本地路徑\x02選擇需要顯示目錄列表的文件夾。\x02移除前綴\x02負載均衡\x02分組名稱\x02分組密" +
-	"鑰\x02健康檢查\x02檢查類型\x02檢查超時\x02錯誤次數\x02檢查週期\x02* 參考 FRP 支持的參數。\x02代理已存在" +
-	"\x02代理名「%[1]s」已存在。\x02打開日誌文件夾\x02最新\x02未知\x02正在運行\x02已停止\x02正在啟動\x02正在停止" +
+	"輯\x02打開文件\x02在文件夾中顯示\x02創建副本\x02全部\x02僅通用配置\x02導入配置\x02從文件導入\x02從 URL " +
+	"導入\x02從剪貼板導入\x02NAT 檢測\x02復制分享鏈接\x02導出所有配置 (ZIP 壓縮包)\x02刪除\x02新建配置\x02" +
+	"手動設置\x02導入了 %[2]d 個配置文件中的 %[1]d 個。\x02另一個同名的配置「%[1]s」已存在。\x02文件 \x22%[" +
+	"1]s\x22 不是有效的壓縮文件。\x02刪除配置「%[1]s」\x02確定要刪除配置「%[1]s」嗎？此操作無法撤銷。\x02新建客戶端" +
+	"\x02編輯客戶端 - %[1]s\x02基本\x02名稱\x02服務器地址\x02服務器端口\x02用戶名\x02STUN 服務\x02認證" +
+	"\x02認證方式\x02無\x02令牌\x02密鑰\x02接收者\x02作用域\x02令牌地址\x02鑑權\x02心跳消息\x02工作連接" +
+	"\x02日誌\x02* 留空則不記錄日誌，且刪除原來的日誌文件。\x02日誌文件\x02選擇日誌文件\x02級別\x02最大天數\x02管理" +
+	"\x02管理地址\x02管理端口\x02密碼\x02靜態資源\x02選擇管理服務器使用的靜態資源目錄。\x02自動刪除\x02絕對\x02相對" +
+	"\x02刪除日期\x02刪除天數\x02天\x02連接\x02協議\x02HTTP 代理\x02連接池數量\x02心跳\x02間隔\x02秒" +
+	"\x02超時\x02連接超時\x02保活週期\x02閒置超時\x02最大流數量\x02開啟\x02關閉\x02主機名稱\x02證書文件\x02選" +
+	"擇證書文件\x02密鑰文件\x02選擇證書密鑰文件\x02受信任證書\x02選擇受信任的證書\x02高級\x02多路復用\x02復用器心跳" +
+	"\x02使用源地址\x02其他選項\x02初次登錄失敗後退出\x02禁用開機自啟動\x02自定義\x02自定義參數\x02* 參考 FRP 配置" +
+	"文件的 [common] 部分。\x02配置已存在\x02配置名「%[1]s」已存在。\x02新建代理\x02編輯代理 - %[1]s" +
+	"\x02隨機名稱\x02類型\x02角色\x02訪問者\x02私鑰\x02本地地址\x02本地端口\x02遠程端口\x02綁定地址\x02綁定端" +
+	"口\x02服務名稱\x02子域名\x02自定義域名\x02URL 路由\x02復用器\x02路由用戶\x02客戶端\x02服務端\x02帶寬" +
+	"限流\x02代理版本\x02空\x02加密傳輸\x02壓縮傳輸\x02HTTP 用戶\x02HTTP 密碼\x02Host 替換\x02插件" +
+	"\x02插件名稱\x02Unix 路徑\x02選擇 Unix 路徑\x02本地路徑\x02選擇需要顯示目錄列表的文件夾。\x02移除前綴\x02" +
+	"負載均衡\x02分組名稱\x02分組密鑰\x02健康檢查\x02檢查類型\x02檢查超時\x02錯誤次數\x02檢查週期\x02* 參考 F" +
+	"RP 支持的參數。\x02代理已存在\x02代理名「%[1]s」已存在。\x02打開日誌文件夾\x02最新\x02項目\x02值\x02NAT " +
+	"類型\x02行為\x02外部地址\x02是\x02否\x02公網\x02未知\x02正在運行\x02已停止\x02正在啟動\x02正在停止" +
 	"\x02狀態\x02遠程地址\x02複製\x02啟動\x02服務\x02停止\x02本地目錄\x02添加\x02端口\x02打開端口\x02選項" +
 	"\x02主密碼\x02您可以設置密碼來限制訪問此程式。\x0a在下次使用此程式時，您將被要求輸入密碼。\x02使用主密碼\x02修改密碼\x02" +
 	"語言\x02目前的顯示語言\x02您必須重新啟動程式才能應用修改。\x02選擇語言\x02默認值\x02定義新建配置時的默認值。\x0a此處" +
@@ -1012,4 +1048,4 @@ const zh_TWData string = "" + // Size: 4029 bytes
 	"請重新輸入。\x02輸入無效\x02請輸入一個從 %.[1]f 到 %.[2]f 的數字。\x02請輸入一個從 %[1]s 到 %[2]s " +
 	"的數字。\x02文本與要求的模式不匹配。\x02必填項\x02請選擇其中一個選項。\x02需要選擇。"
 
-	// Total table size 34683 bytes (33KiB); checksum: F8713DA1
+	// Total table size 35515 bytes (34KiB); checksum: 3D1B5351

--- a/i18n/locales/en-US/messages.gotext.json
+++ b/i18n/locales/en-US/messages.gotext.json
@@ -304,6 +304,13 @@
             "fuzzy": true
         },
         {
+            "id": "Import Config",
+            "message": "Import Config",
+            "translation": "Import Config",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "Import from File",
             "message": "Import from File",
             "translation": "Import from File",
@@ -321,6 +328,13 @@
             "id": "Import from Clipboard",
             "message": "Import from Clipboard",
             "translation": "Import from Clipboard",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "NAT Discovery",
+            "message": "NAT Discovery",
+            "translation": "NAT Discovery",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -356,13 +370,6 @@
             "id": "Manual Settings",
             "message": "Manual Settings",
             "translation": "Manual Settings",
-            "translatorComment": "Copied from source.",
-            "fuzzy": true
-        },
-        {
-            "id": "Import Config",
-            "message": "Import Config",
-            "translation": "Import Config",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -515,6 +522,13 @@
             "id": "User",
             "message": "User",
             "translation": "User",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "STUN Server",
+            "message": "STUN Server",
+            "translation": "STUN Server",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -1315,6 +1329,62 @@
             "id": "Latest",
             "message": "Latest",
             "translation": "Latest",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Item",
+            "message": "Item",
+            "translation": "Item",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Value",
+            "message": "Value",
+            "translation": "Value",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "NAT Type",
+            "message": "NAT Type",
+            "translation": "NAT Type",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Behavior",
+            "message": "Behavior",
+            "translation": "Behavior",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "External Address",
+            "message": "External Address",
+            "translation": "External Address",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Yes",
+            "message": "Yes",
+            "translation": "Yes",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "No",
+            "message": "No",
+            "translation": "No",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Public Network",
+            "message": "Public Network",
+            "translation": "Public Network",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },

--- a/i18n/locales/es-ES/messages.gotext.json
+++ b/i18n/locales/es-ES/messages.gotext.json
@@ -232,6 +232,11 @@
             "translation": "Solo común"
         },
         {
+            "id": "Import Config",
+            "message": "Import Config",
+            "translation": "Importar configuración"
+        },
+        {
             "id": "Import from File",
             "message": "Import from File",
             "translation": "Importar desde archivo"
@@ -245,6 +250,11 @@
             "id": "Import from Clipboard",
             "message": "Import from Clipboard",
             "translation": "Importar desde portapapeles"
+        },
+        {
+            "id": "NAT Discovery",
+            "message": "NAT Discovery",
+            "translation": "Detección de NAT"
         },
         {
             "id": "Copy Share Link",
@@ -270,11 +280,6 @@
             "id": "Manual Settings",
             "message": "Manual Settings",
             "translation": "Ajustes manuales"
-        },
-        {
-            "id": "Import Config",
-            "message": "Import Config",
-            "translation": "Importar configuración"
         },
         {
             "id": "Imported {Imported} of {Total} configs.",
@@ -403,6 +408,11 @@
             "id": "User",
             "message": "User",
             "translation": "Usuario"
+        },
+        {
+            "id": "STUN Server",
+            "message": "STUN Server",
+            "translation": "Servidor STUN"
         },
         {
             "id": "Auth",
@@ -983,6 +993,46 @@
             "id": "Latest",
             "message": "Latest",
             "translation": "Último"
+        },
+        {
+            "id": "Item",
+            "message": "Item",
+            "translation": "Ítem"
+        },
+        {
+            "id": "Value",
+            "message": "Value",
+            "translation": "Valorizar"
+        },
+        {
+            "id": "NAT Type",
+            "message": "NAT Type",
+            "translation": "Tipo de NAT"
+        },
+        {
+            "id": "Behavior",
+            "message": "Behavior",
+            "translation": "Comportamiento"
+        },
+        {
+            "id": "External Address",
+            "message": "External Address",
+            "translation": "Dirección externa"
+        },
+        {
+            "id": "Yes",
+            "message": "Yes",
+            "translation": "Sí"
+        },
+        {
+            "id": "No",
+            "message": "No",
+            "translation": "No"
+        },
+        {
+            "id": "Public Network",
+            "message": "Public Network",
+            "translation": "Red pública"
         },
         {
             "id": "Unknown",

--- a/i18n/locales/ja-JP/messages.gotext.json
+++ b/i18n/locales/ja-JP/messages.gotext.json
@@ -232,6 +232,11 @@
             "translation": "共通設定のみ"
         },
         {
+            "id": "Import Config",
+            "message": "Import Config",
+            "translation": "設定のインポート"
+        },
+        {
             "id": "Import from File",
             "message": "Import from File",
             "translation": "ファイルからインポート"
@@ -245,6 +250,11 @@
             "id": "Import from Clipboard",
             "message": "Import from Clipboard",
             "translation": "クリップボードからインポート"
+        },
+        {
+            "id": "NAT Discovery",
+            "message": "NAT Discovery",
+            "translation": "NAT 検出"
         },
         {
             "id": "Copy Share Link",
@@ -270,11 +280,6 @@
             "id": "Manual Settings",
             "message": "Manual Settings",
             "translation": "手動設定"
-        },
-        {
-            "id": "Import Config",
-            "message": "Import Config",
-            "translation": "設定のインポート"
         },
         {
             "id": "Imported {Imported} of {Total} configs.",
@@ -413,6 +418,11 @@
             "id": "User",
             "message": "User",
             "translation": "ユーザー"
+        },
+        {
+            "id": "STUN Server",
+            "message": "STUN Server",
+            "translation": "STUNサーバー"
         },
         {
             "id": "Auth",
@@ -993,6 +1003,46 @@
             "id": "Latest",
             "message": "Latest",
             "translation": "最新"
+        },
+        {
+            "id": "Item",
+            "message": "Item",
+            "translation": "項目"
+        },
+        {
+            "id": "Value",
+            "message": "Value",
+            "translation": "値"
+        },
+        {
+            "id": "NAT Type",
+            "message": "NAT Type",
+            "translation": "NAT タイプ"
+        },
+        {
+            "id": "Behavior",
+            "message": "Behavior",
+            "translation": "挙動"
+        },
+        {
+            "id": "External Address",
+            "message": "External Address",
+            "translation": "外部アドレス"
+        },
+        {
+            "id": "Yes",
+            "message": "Yes",
+            "translation": "はい"
+        },
+        {
+            "id": "No",
+            "message": "No",
+            "translation": "いいえ"
+        },
+        {
+            "id": "Public Network",
+            "message": "Public Network",
+            "translation": "公共のネットワーク"
         },
         {
             "id": "Unknown",

--- a/i18n/locales/ko-KR/messages.gotext.json
+++ b/i18n/locales/ko-KR/messages.gotext.json
@@ -232,6 +232,11 @@
             "translation": "일반 구성만 해당"
         },
         {
+            "id": "Import Config",
+            "message": "Import Config",
+            "translation": "구성 가져오기"
+        },
+        {
             "id": "Import from File",
             "message": "Import from File",
             "translation": "파일에서 가져오기"
@@ -245,6 +250,11 @@
             "id": "Import from Clipboard",
             "message": "Import from Clipboard",
             "translation": "클립보드에서 가져오기"
+        },
+        {
+            "id": "NAT Discovery",
+            "message": "NAT Discovery",
+            "translation": "NAT 검색"
         },
         {
             "id": "Copy Share Link",
@@ -270,11 +280,6 @@
             "id": "Manual Settings",
             "message": "Manual Settings",
             "translation": "수동 설정"
-        },
-        {
-            "id": "Import Config",
-            "message": "Import Config",
-            "translation": "구성 가져오기"
         },
         {
             "id": "Imported {Imported} of {Total} configs.",
@@ -403,6 +408,11 @@
             "id": "User",
             "message": "User",
             "translation": "사용자"
+        },
+        {
+            "id": "STUN Server",
+            "message": "STUN Server",
+            "translation": "STUN 서버"
         },
         {
             "id": "Auth",
@@ -983,6 +993,46 @@
             "id": "Latest",
             "message": "Latest",
             "translation": "최신"
+        },
+        {
+            "id": "Item",
+            "message": "Item",
+            "translation": "안건"
+        },
+        {
+            "id": "Value",
+            "message": "Value",
+            "translation": "값"
+        },
+        {
+            "id": "NAT Type",
+            "message": "NAT Type",
+            "translation": "NAT 유형"
+        },
+        {
+            "id": "Behavior",
+            "message": "Behavior",
+            "translation": "행실"
+        },
+        {
+            "id": "External Address",
+            "message": "External Address",
+            "translation": "외부 주소"
+        },
+        {
+            "id": "Yes",
+            "message": "Yes",
+            "translation": "예"
+        },
+        {
+            "id": "No",
+            "message": "No",
+            "translation": "아니요"
+        },
+        {
+            "id": "Public Network",
+            "message": "Public Network",
+            "translation": "공용 네트워크"
         },
         {
             "id": "Unknown",

--- a/i18n/locales/zh-CN/messages.gotext.json
+++ b/i18n/locales/zh-CN/messages.gotext.json
@@ -232,6 +232,11 @@
             "translation": "仅通用配置"
         },
         {
+            "id": "Import Config",
+            "message": "Import Config",
+            "translation": "导入配置"
+        },
+        {
             "id": "Import from File",
             "message": "Import from File",
             "translation": "从文件导入"
@@ -245,6 +250,11 @@
             "id": "Import from Clipboard",
             "message": "Import from Clipboard",
             "translation": "从剪贴板导入"
+        },
+        {
+            "id": "NAT Discovery",
+            "message": "NAT Discovery",
+            "translation": "NAT 检测"
         },
         {
             "id": "Copy Share Link",
@@ -270,11 +280,6 @@
             "id": "Manual Settings",
             "message": "Manual Settings",
             "translation": "手动设置"
-        },
-        {
-            "id": "Import Config",
-            "message": "Import Config",
-            "translation": "导入配置"
         },
         {
             "id": "Imported {Imported} of {Total} configs.",
@@ -403,6 +408,11 @@
             "id": "User",
             "message": "User",
             "translation": "用户名"
+        },
+        {
+            "id": "STUN Server",
+            "message": "STUN Server",
+            "translation": "STUN 服务"
         },
         {
             "id": "Auth",
@@ -983,6 +993,46 @@
             "id": "Latest",
             "message": "Latest",
             "translation": "最新"
+        },
+        {
+            "id": "Item",
+            "message": "Item",
+            "translation": "项目"
+        },
+        {
+            "id": "Value",
+            "message": "Value",
+            "translation": "值"
+        },
+        {
+            "id": "NAT Type",
+            "message": "NAT Type",
+            "translation": "NAT 类型"
+        },
+        {
+            "id": "Behavior",
+            "message": "Behavior",
+            "translation": "行为"
+        },
+        {
+            "id": "External Address",
+            "message": "External Address",
+            "translation": "外部地址"
+        },
+        {
+            "id": "Yes",
+            "message": "Yes",
+            "translation": "是"
+        },
+        {
+            "id": "No",
+            "message": "No",
+            "translation": "否"
+        },
+        {
+            "id": "Public Network",
+            "message": "Public Network",
+            "translation": "公网"
         },
         {
             "id": "Unknown",

--- a/i18n/locales/zh-TW/messages.gotext.json
+++ b/i18n/locales/zh-TW/messages.gotext.json
@@ -232,6 +232,11 @@
             "translation": "僅通用配置"
         },
         {
+            "id": "Import Config",
+            "message": "Import Config",
+            "translation": "導入配置"
+        },
+        {
             "id": "Import from File",
             "message": "Import from File",
             "translation": "從文件導入"
@@ -245,6 +250,11 @@
             "id": "Import from Clipboard",
             "message": "Import from Clipboard",
             "translation": "從剪貼板導入"
+        },
+        {
+            "id": "NAT Discovery",
+            "message": "NAT Discovery",
+            "translation": "NAT 檢測"
         },
         {
             "id": "Copy Share Link",
@@ -270,11 +280,6 @@
             "id": "Manual Settings",
             "message": "Manual Settings",
             "translation": "手動設置"
-        },
-        {
-            "id": "Import Config",
-            "message": "Import Config",
-            "translation": "導入配置"
         },
         {
             "id": "Imported {Imported} of {Total} configs.",
@@ -403,6 +408,11 @@
             "id": "User",
             "message": "User",
             "translation": "用戶名"
+        },
+        {
+            "id": "STUN Server",
+            "message": "STUN Server",
+            "translation": "STUN 服務"
         },
         {
             "id": "Auth",
@@ -983,6 +993,46 @@
             "id": "Latest",
             "message": "Latest",
             "translation": "最新"
+        },
+        {
+            "id": "Item",
+            "message": "Item",
+            "translation": "項目"
+        },
+        {
+            "id": "Value",
+            "message": "Value",
+            "translation": "值"
+        },
+        {
+            "id": "NAT Type",
+            "message": "NAT Type",
+            "translation": "NAT 類型"
+        },
+        {
+            "id": "Behavior",
+            "message": "Behavior",
+            "translation": "行為"
+        },
+        {
+            "id": "External Address",
+            "message": "External Address",
+            "translation": "外部地址"
+        },
+        {
+            "id": "Yes",
+            "message": "Yes",
+            "translation": "是"
+        },
+        {
+            "id": "No",
+            "message": "No",
+            "translation": "否"
+        },
+        {
+            "id": "Public Network",
+            "message": "Public Network",
+            "translation": "公網"
         },
         {
             "id": "Unknown",

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -46,6 +46,7 @@ type ClientCommon struct {
 	ClientAuth              `ini:",extends"`
 	ServerAddress           string   `ini:"server_addr,omitempty"`
 	ServerPort              string   `ini:"server_port,omitempty"`
+	NatHoleSTUNServer       string   `ini:"nat_hole_stun_server,omitempty"`
 	DialServerTimeout       int64    `ini:"dial_server_timeout,omitempty"`
 	DialServerKeepAlive     int64    `ini:"dial_server_keepalive,omitempty"`
 	ConnectServerLocalIP    string   `ini:"connect_server_local_ip,omitempty"`
@@ -245,6 +246,10 @@ func (conf *ClientConfig) AutoStart() bool {
 
 func (conf *ClientConfig) GetLogFile() string {
 	return conf.LogFile
+}
+
+func (conf *ClientConfig) GetSTUNServer() string {
+	return conf.NatHoleSTUNServer
 }
 
 func (conf *ClientConfig) Expiry() bool {

--- a/pkg/config/conf.go
+++ b/pkg/config/conf.go
@@ -37,6 +37,8 @@ type Config interface {
 	AutoStart() bool
 	// Expiry indicates whether the config has an expiry date.
 	Expiry() bool
+	// GetSTUNServer returns the STUN server to help penetrate NAT hole.
+	GetSTUNServer() string
 	// Copy creates a new copy of this config.
 	Copy(all bool) Config
 }

--- a/pkg/consts/res.go
+++ b/pkg/consts/res.go
@@ -57,6 +57,7 @@ const (
 	IconDefaults     = 156
 	IconKey          = 29
 	IconLanguage     = 89
+	IconNat          = 159
 )
 
 // Colors

--- a/pkg/consts/res.go
+++ b/pkg/consts/res.go
@@ -57,7 +57,7 @@ const (
 	IconDefaults     = 156
 	IconKey          = 29
 	IconLanguage     = 89
-	IconNat          = 159
+	IconNat          = 0
 )
 
 // Colors

--- a/ui/composite.go
+++ b/ui/composite.go
@@ -34,7 +34,11 @@ func NewBasicDialog(assignTo **walk.Dialog, title string, icon Property, db Data
 	if yes == nil {
 		// Default handler for "yes" button
 		yes = func() {
-			if err := (*assignTo).DataBinder().Submit(); err == nil {
+			if binder := (*assignTo).DataBinder(); binder != nil {
+				if err := binder.Submit(); err == nil {
+					(*assignTo).Accept()
+				}
+			} else {
 				(*assignTo).Accept()
 			}
 		}

--- a/ui/confview.go
+++ b/ui/confview.go
@@ -550,7 +550,7 @@ func (cv *ConfView) onNATDiscovery() {
 	if stunServer == "" {
 		stunServer = frpConfig.GetDefaultClientConf().NatHoleSTUNServer
 	}
-	if _, err := NewNATDiscoverDialog(stunServer).Run(cv.Form()); err != nil {
+	if _, err := NewNATDiscoveryDialog(stunServer).Run(cv.Form()); err != nil {
 		showError(err, cv.Form())
 	}
 }

--- a/ui/editclient.go
+++ b/ui/editclient.go
@@ -125,6 +125,8 @@ func (cd *EditClientDialog) basicConfPage() TabPage {
 			LineEdit{Text: Bind("ServerPort", consts.ValidateRequireInteger)},
 			Label{Text: i18n.SprintfColon("User")},
 			LineEdit{Text: Bind("User")},
+			Label{Text: i18n.SprintfColon("STUN Server")},
+			LineEdit{Text: Bind("NatHoleSTUNServer")},
 			VSpacer{ColumnSpan: 2},
 		},
 	}

--- a/ui/model.go
+++ b/ui/model.go
@@ -164,3 +164,19 @@ func (m *LogModel) Reset() error {
 	m.lines = lines
 	return nil
 }
+
+// NonSortedModel preserves the original order of items
+// in the slice.
+type NonSortedModel[T any] struct {
+	walk.ReflectTableModelBase
+
+	items []*T
+}
+
+func NewNonSortedModel[T any](items []*T) *NonSortedModel[T] {
+	return &NonSortedModel[T]{items: items}
+}
+
+func (m *NonSortedModel[T]) Items() interface{} {
+	return m.items
+}

--- a/ui/nathole.go
+++ b/ui/nathole.go
@@ -1,0 +1,118 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/fatedier/frp/pkg/nathole"
+	"github.com/lxn/walk"
+	. "github.com/lxn/walk/declarative"
+
+	"github.com/koho/frpmgr/i18n"
+	"github.com/koho/frpmgr/pkg/consts"
+)
+
+type NATDiscoveryDialog struct {
+	*walk.Dialog
+
+	table   *walk.TableView
+	barView *walk.ProgressBar
+
+	// STUN server address
+	serverAddr string
+	closed     bool
+}
+
+func NewNATDiscoverDialog(serverAddr string) *NATDiscoveryDialog {
+	return &NATDiscoveryDialog{serverAddr: serverAddr}
+}
+
+func (nd *NATDiscoveryDialog) Run(owner walk.Form) (int, error) {
+	dlg := NewBasicDialog(&nd.Dialog, i18n.Sprintf("NAT Discovery"), loadSysIcon("shell32", consts.IconNat, 32),
+		DataBinder{}, nil,
+		VSpacer{Size: 1},
+		Composite{
+			Layout: HBox{MarginsZero: true},
+			Children: []Widget{
+				Label{Text: i18n.SprintfColon("STUN Server")},
+				TextEdit{Text: nd.serverAddr, ReadOnly: true, CompactHeight: true},
+			},
+		},
+		VSpacer{Size: 1},
+		TableView{
+			Name:     "tb",
+			Visible:  false,
+			AssignTo: &nd.table,
+			Columns: []TableViewColumn{
+				{Title: i18n.Sprintf("Item"), DataMember: "Name", Width: 180},
+				{Title: i18n.Sprintf("Value"), DataMember: "DisplayName", Width: 180},
+			},
+		},
+		ProgressBar{AssignTo: &nd.barView, Visible: Bind("!tb.Visible"), MarqueeMode: true},
+		VSpacer{},
+	)
+	dlg.MinSize = Size{Width: 400, Height: 350}
+	if err := dlg.Create(owner); err != nil {
+		return 0, err
+	}
+	nd.barView.SetFocus()
+	nd.Closing().Attach(func(canceled *bool, reason walk.CloseReason) {
+		nd.closed = true
+	})
+
+	// Start discovering NAT type
+	go nd.discover()
+
+	return nd.Dialog.Run(), nil
+}
+
+func (nd *NATDiscoveryDialog) discover() (err error) {
+	defer nd.Synchronize(func() {
+		if err != nil && !nd.closed {
+			nd.barView.SetMarqueeMode(false)
+			showError(err, nd.Form())
+			nd.Cancel()
+		}
+	})
+	addrs, localAddr, err := nathole.Discover([]string{nd.serverAddr}, "")
+	if err != nil {
+		return err
+	}
+	if len(addrs) < 2 {
+		return fmt.Errorf("can not get enough addresses, need 2, got: %v\n", addrs)
+	}
+
+	localIPs, _ := nathole.ListLocalIPsForNatHole(10)
+
+	natFeature, err := nathole.ClassifyNATFeature(addrs, localIPs)
+	if err != nil {
+		return err
+	}
+	items := []*StringPair{
+		{Name: i18n.Sprintf("NAT Type"), DisplayName: natFeature.NatType},
+		{Name: i18n.Sprintf("Behavior"), DisplayName: natFeature.Behavior},
+		{Name: i18n.Sprintf("Local Address"), DisplayName: localAddr.String()},
+	}
+	for _, addr := range addrs {
+		items = append(items, &StringPair{
+			Name:        i18n.Sprintf("External Address"),
+			DisplayName: addr,
+		})
+	}
+	var public string
+	if natFeature.PublicNetwork {
+		public = i18n.Sprintf("Yes")
+	} else {
+		public = i18n.Sprintf("No")
+	}
+	items = append(items, &StringPair{
+		Name:        i18n.Sprintf("Public Network"),
+		DisplayName: public,
+	})
+	nd.table.Synchronize(func() {
+		nd.table.SetVisible(true)
+		if err = nd.table.SetModel(NewNonSortedModel(items)); err != nil {
+			showError(err, nd.Form())
+		}
+	})
+	return nil
+}

--- a/ui/nathole.go
+++ b/ui/nathole.go
@@ -22,7 +22,7 @@ type NATDiscoveryDialog struct {
 	closed     bool
 }
 
-func NewNATDiscoverDialog(serverAddr string) *NATDiscoveryDialog {
+func NewNATDiscoveryDialog(serverAddr string) *NATDiscoveryDialog {
 	return &NATDiscoveryDialog{serverAddr: serverAddr}
 }
 

--- a/ui/nathole.go
+++ b/ui/nathole.go
@@ -27,7 +27,7 @@ func NewNATDiscoverDialog(serverAddr string) *NATDiscoveryDialog {
 }
 
 func (nd *NATDiscoveryDialog) Run(owner walk.Form) (int, error) {
-	dlg := NewBasicDialog(&nd.Dialog, i18n.Sprintf("NAT Discovery"), loadSysIcon("shell32", consts.IconNat, 32),
+	dlg := NewBasicDialog(&nd.Dialog, i18n.Sprintf("NAT Discovery"), loadSysIcon("firewallcontrolpanel", consts.IconNat, 32),
 		DataBinder{}, nil,
 		VSpacer{Size: 1},
 		Composite{

--- a/ui/prefpage.go
+++ b/ui/prefpage.go
@@ -238,6 +238,8 @@ func (pp *PrefPage) setDefaultValue() (int, error) {
 				NumberEdit{Value: Bind("DeleteAfterDays"), Suffix: i18n.SprintfLSpace("Days")},
 				Label{Text: "DNS:"},
 				LineEdit{Text: Bind("DNSServer")},
+				Label{Text: i18n.SprintfColon("STUN Server")},
+				LineEdit{Text: Bind("NatHoleSTUNServer")},
 				Label{Text: i18n.SprintfColon("Source Address")},
 				LineEdit{Text: Bind("ConnectServerLocalIP")},
 				Composite{


### PR DESCRIPTION
This PR introduces a NAT type tester that shows the NAT information of current network. If the STUN server is set in config, it would be used as a discovery provider. Otherwise, the default STUN server is used.