### PR TITLE
Enable TLS by default

### DIFF
--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -71,7 +71,7 @@ type ClientCommon struct {
 	HeartbeatTimeout        int64    `ini:"heartbeat_timeout,omitempty"`
 	TCPMux                  bool     `ini:"tcp_mux"`
 	TCPMuxKeepaliveInterval int64    `ini:"tcp_mux_keepalive_interval,omitempty"`
-	TLSEnable               bool     `ini:"tls_enable,omitempty"`
+	TLSEnable               bool     `ini:"tls_enable"`
 	TLSCertFile             string   `ini:"tls_cert_file,omitempty"`
 	TLSKeyFile              string   `ini:"tls_key_file,omitempty"`
 	TLSTrustedCaFile        string   `ini:"tls_trusted_ca_file,omitempty"`
@@ -512,6 +512,7 @@ func NewDefaultClientConfig() *ClientConfig {
 			ServerPort: "7000",
 			LogLevel:   "info",
 			TCPMux:     true,
+			TLSEnable:  true,
 			AutoDelete: AutoDelete{DeleteMethod: consts.DeleteRelative},
 		},
 		Proxies: make([]*Proxy, 0),

--- a/ui/conf.go
+++ b/ui/conf.go
@@ -83,6 +83,7 @@ var (
 		LogLevel:   "info",
 		LogMaxDays: 3,
 		TCPMux:     true,
+		TLSEnable:  true,
 	}}
 	// The config list contains all the loaded configs
 	confList  []*Conf

--- a/ui/prefpage.go
+++ b/ui/prefpage.go
@@ -250,9 +250,10 @@ func (pp *PrefPage) setDefaultValue() (int, error) {
 					},
 				},
 				Composite{
-					Layout: VBox{MarginsZero: true, SpacingZero: true, Alignment: AlignHNearVNear},
+					Layout: Grid{MarginsZero: true, SpacingZero: true, Columns: 2},
 					Children: []Widget{
 						CheckBox{Text: i18n.Sprintf("TCP Mux"), Checked: Bind("TCPMux")},
+						CheckBox{Text: "TLS", Checked: Bind("TLSEnable")},
 						CheckBox{Text: i18n.Sprintf("Disable auto-start at boot"), Checked: Bind("ManualStart")},
 					},
 				},


### PR DESCRIPTION
Since frp [v0.50.0](https://github.com/fatedier/frp/releases/tag/v0.50.0), the default values for `tls_enable` and `disable_custom_tls_first_byte` have been set to true.
