### PR TITLE
Support TOML/YAML/JSON format files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/lxn/walk v0.0.0-20210112085537-c389da54e794
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
 	github.com/miekg/dns v1.1.58
+	github.com/samber/lo v1.38.1
 	github.com/thoas/go-funk v0.9.3
 	golang.org/x/sys v0.17.0
 	golang.org/x/text v0.14.0
@@ -42,7 +43,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/quic-go/qtls-go1-20 v0.3.1 // indirect
 	github.com/quic-go/quic-go v0.37.7 // indirect
-	github.com/samber/lo v1.38.1 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/templexxx/cpufeat v0.0.0-20180724012125-cef66df7f161 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lxn/walk v0.0.0-20210112085537-c389da54e794
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
 	github.com/miekg/dns v1.1.58
-	github.com/samber/lo v1.38.1
+	github.com/samber/lo v1.39.0
 	github.com/thoas/go-funk v0.9.3
 	golang.org/x/sys v0.17.0
 	golang.org/x/text v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/quic-go/quic-go v0.37.7 h1:AgKsQLZ1+YCwZd2GYhBUsJDYZwEkA5gENtAjb+MxON
 github.com/quic-go/quic-go v0.37.7/go.mod h1:YsbH1r4mSHPJcLF4k4zruUkLBqctEMBDR6VPvcYjIsU=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
-github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
+github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/i18n/catalog.go
+++ b/i18n/catalog.go
@@ -43,265 +43,270 @@ func init() {
 }
 
 var messageKeyToIndex = map[string]int{
-	"* Leave blank to record no log and delete the original log file.":  71,
-	"* Refer to the [common] section of the FRP configuration file.":    119,
-	"* Refer to the parameters supported by FRP.":                       177,
-	"* Support batch import, one link per line.":                        240,
-	"* The following features may affect the stability of the service.": 120,
-	"A selection is required.":                                          255,
+	"* Leave blank to record no log and delete the original log file.":  72,
+	"* Refer to the [common] section of the FRP configuration file.":    121,
+	"* Refer to the parameters supported by FRP.":                       181,
+	"* Support batch import, one link per line.":                        245,
+	"* The following features may affect the stability of the service.": 122,
+	"A selection is required.":                                          260,
 	"About":                                                             15,
-	"Absolute":                                                          83,
-	"Add":                                                               204,
-	"Admin":                                                             76,
-	"Admin Address":                                                     77,
-	"Admin Port":                                                        78,
-	"Advanced":                                                          109,
+	"Absolute":                                                          84,
+	"Add":                                                               208,
+	"Admin":                                                             77,
+	"Admin Address":                                                     78,
+	"Advanced":                                                          112,
 	"All":                                                               34,
 	"All Files":                                                         3,
-	"Allow Users":                                                       135,
+	"Allow Users":                                                       138,
 	"An error occurred while checking for a software update.": 21,
 	"Another config already exists with the name \"%s\".":     47,
 	"Are you sure you would like to delete config \"%s\"?":    50,
-	"Are you sure you would like to delete proxy \"%s\"?":     234,
-	"Are you sure you would like to disable proxy \"%s\"?":    236,
-	"Are you sure you would like to stop config \"%s\"?":      201,
+	"Are you sure you would like to delete proxy \"%s\"?":     239,
+	"Are you sure you would like to disable proxy \"%s\"?":    241,
+	"Are you sure you would like to stop config \"%s\"?":      205,
 	"Assets":                 80,
 	"Audience":               64,
 	"Auth":                   59,
 	"Auth Method":            60,
-	"Authentication":         67,
-	"Auto Delete":            82,
-	"Bandwidth":              146,
+	"Authentication":         68,
+	"Auto Delete":            83,
+	"Bandwidth":              150,
 	"Basic":                  53,
-	"Behavior":               185,
-	"Bind Address":           136,
-	"Bind Port":              137,
+	"Behavior":               189,
+	"Bind Address":           139,
+	"Bind Port":              140,
 	"Built on: %s":           2,
 	"Cancel":                 24,
-	"Certificate":            103,
+	"Certificate":            105,
 	"Certificate Files":      5,
-	"Certificate Key":        105,
-	"Change Password":        211,
-	"Check Interval":         176,
-	"Check Timeout":          174,
-	"Check Type":             173,
+	"Certificate Key":        107,
+	"Change Password":        215,
+	"Check Interval":         180,
+	"Check Timeout":          178,
+	"Check Type":             177,
 	"Check for updates":      18,
 	"Checking for updates":   17,
-	"Client":                 145,
+	"Clear All":              124,
+	"Client":                 149,
 	"Common Only":            35,
-	"Compression":            152,
-	"Config already exists":  122,
+	"Compression":            156,
+	"Config already exists":  125,
 	"Config already removed": 28,
 	"Configuration":          25,
 	"Configuration Files":    4,
-	"Connection":             88,
-	"Copy":                   197,
-	"Copy Access Address":    232,
+	"Connection":             89,
+	"Copy":                   201,
+	"Copy Access Address":    236,
 	"Copy Share Link":        41,
 	"Create a Copy":          33,
-	"Custom":                 116,
-	"Custom Domains":         141,
-	"Custom Options":         118,
-	"Days":                   87,
-	"Defaults":               216,
-	"Define the default value when creating a new configuration.\nThe value here will not affect the existing configuration.": 217,
+	"Custom Domains":         144,
+	"Custom Options":         120,
+	"Days":                   88,
+	"Defaults":               220,
+	"Define the default value when creating a new configuration.\nThe value here will not affect the existing configuration.": 221,
 	"Delete":                        43,
-	"Delete Date":                   85,
-	"Delete Days":                   86,
+	"Delete Date":                   86,
+	"Delete Days":                   87,
 	"Delete config \"%s\"":          49,
-	"Delete proxy \"%s\"":           233,
-	"Dial Timeout":                  96,
-	"Direct Edit":                   230,
-	"Disable":                       237,
-	"Disable auto-start at boot":    115,
-	"Disable proxy \"%s\"":          235,
-	"Domains":                       231,
-	"Download":                      244,
+	"Delete proxy \"%s\"":           238,
+	"Dial Timeout":                  98,
+	"Direct Edit":                   234,
+	"Disable":                       242,
+	"Disable auto-start at boot":    117,
+	"Disable custom first byte":     111,
+	"Disable proxy \"%s\"":          240,
+	"Domains":                       235,
+	"Download":                      249,
 	"Download updates":              16,
 	"Edit":                          30,
 	"Edit Client - %s":              52,
-	"Edit Proxy - %s":               125,
-	"Enable":                        228,
-	"Encryption":                    151,
-	"Enter Administration Password": 247,
-	"Enter Password":                245,
-	"Exit after login failure":      114,
-	"Experimental Features":         117,
+	"Edit Proxy - %s":               128,
+	"Enable":                        232,
+	"Encryption":                    155,
+	"Enter Administration Password": 252,
+	"Enter Password":                250,
+	"Exit after login failure":      116,
+	"Experimental Features":         119,
 	"Export All Configs to ZIP":     42,
-	"External Address":              186,
-	"FRP Manager":                   239,
+	"External Address":              190,
+	"FRP Manager":                   244,
 	"FRP version: %s":               1,
-	"Failure Count":                 175,
-	"Fallback":                      156,
-	"Fallback Timeout":              157,
+	"Failure Count":                 179,
+	"Fallback":                      160,
+	"Fallback Timeout":              161,
 	"For FRP configuration documentation, please visit the FRP project page:": 20,
 	"For comments or to report bugs, please visit the project page:":          19,
-	"Group":                                  170,
-	"Group Key":                              171,
-	"HTTP File Server":                       227,
-	"HTTP Password":                          160,
-	"HTTP Proxy":                             90,
-	"HTTP User":                              159,
-	"Health Check":                           172,
-	"Heart Beats":                            68,
-	"Heartbeat":                              92,
-	"Host Name":                              102,
-	"Host Rewrite":                           161,
-	"Idle Timeout":                           98,
+	"Group":                                  174,
+	"Group Key":                              175,
+	"HTTP File Server":                       231,
+	"HTTP Password":                          164,
+	"HTTP Proxy":                             91,
+	"HTTP User":                              163,
+	"Health Check":                           176,
+	"Heart Beats":                            69,
+	"Heartbeat":                              94,
+	"Host Name":                              104,
+	"Host Rewrite":                           165,
+	"Idle Timeout":                           100,
 	"Import Config":                          36,
 	"Import Config from File":                27,
 	"Import from Clipboard":                  39,
 	"Import from File":                       37,
 	"Import from URL":                        38,
 	"Imported %d of %d configs.":             46,
-	"Interval":                               93,
-	"Invalid Input":                          249,
-	"Item":                                   182,
-	"Keep Tunnel":                            150,
-	"Keepalive":                              97,
+	"Interval":                               95,
+	"Invalid Input":                          254,
+	"Item":                                   186,
+	"Keep Tunnel":                            154,
+	"Keepalive":                              99,
 	"Key Files":                              6,
-	"Languages":                              212,
-	"Latest":                                 181,
-	"Level":                                  74,
-	"Load Balance":                           169,
-	"Local Address":                          132,
-	"Local Directory":                        203,
-	"Local Path":                             166,
-	"Local Port":                             133,
-	"Locations":                              142,
-	"Log":                                    70,
-	"Log File":                               72,
+	"Languages":                              216,
+	"Latest":                                 185,
+	"Level":                                  75,
+	"Load Balance":                           173,
+	"Local Address":                          135,
+	"Local Directory":                        207,
+	"Local Path":                             170,
+	"Local Port":                             136,
+	"Locations":                              145,
+	"Log":                                    71,
+	"Log File":                               73,
 	"Log Files":                              7,
-	"Log Level":                              223,
-	"Log retention":                          224,
+	"Log Level":                              227,
+	"Log retention":                          228,
 	"Manual Settings":                        45,
-	"Master password":                        208,
-	"Max Days":                               75,
-	"Max Streams":                            99,
-	"Multiplexer":                            143,
-	"Mux Keepalive":                          111,
+	"Master password":                        212,
+	"Max Days":                               76,
+	"Max Streams":                            101,
+	"Metadata":                               118,
+	"Multiplexer":                            147,
+	"Mux Keepalive":                          114,
 	"NAT Discovery":                          40,
-	"NAT Type":                               184,
+	"NAT Type":                               188,
 	"Name":                                   54,
 	"New Client":                             51,
 	"New Config":                             44,
 	"New Configuration":                      26,
-	"New Proxy":                              124,
+	"New Proxy":                              127,
 	"New Version!":                           14,
-	"New master password":                    220,
-	"No":                                     188,
+	"New master password":                    224,
+	"No":                                     192,
 	"None":                                   61,
 	"Not a number":                           12,
 	"Number out of allowed range":            8,
 	"OK":                                     23,
-	"Off":                                    101,
-	"On":                                     100,
-	"Open Config":                            229,
+	"Off":                                    103,
+	"On":                                     102,
+	"Open Config":                            233,
 	"Open File":                              31,
-	"Open Log Folder":                        180,
-	"Open Port":                              206,
-	"Other Options":                          113,
-	"Passive Port Range":                     238,
+	"Open Log Folder":                        184,
+	"Open Port":                              210,
+	"Other Options":                          82,
+	"Parameters":                             67,
+	"Passive Port Range":                     243,
 	"Password":                               79,
-	"Password is set.":                       222,
+	"Password is set.":                       226,
 	"Password mismatch":                      10,
-	"Password removed.":                      219,
+	"Password removed.":                      223,
 	"Please check and try again.":            11,
-	"Please enter a number from %.f to %.f.": 250,
-	"Please enter a number from %s to %s.":   251,
+	"Please enter a number from %.f to %.f.": 255,
+	"Please enter a number from %s to %s.":   256,
 	"Please enter a number greater than %d.": 9,
 	"Please enter a valid number.":           13,
-	"Please enter the correct URL list.":     243,
-	"Please select one of the provided options.": 254,
-	"Plugin":                                 162,
-	"Plugin Name":                            163,
-	"Pool Count":                             91,
-	"Port":                                   205,
-	"Preferences":                            207,
-	"Protocol":                               89,
-	"Proxy Protocol":                         147,
-	"Proxy already exists":                   178,
-	"Public Network":                         189,
-	"Quick Add":                              225,
-	"Random":                                 126,
-	"Re-enter password":                      221,
-	"Ready":                                  242,
-	"Relative":                               84,
-	"Remote Address":                         196,
-	"Remote Desktop":                         226,
-	"Remote Port":                            134,
-	"Rename automatically":                   241,
-	"Retry Count":                            153,
-	"Retry Interval":                         155,
-	"Role":                                   128,
-	"Route User":                             144,
-	"Running":                                191,
+	"Please enter the correct URL list.":     248,
+	"Please select one of the provided options.": 259,
+	"Plugin":                                 166,
+	"Plugin Name":                            167,
+	"Pool Count":                             92,
+	"Port":                                   209,
+	"Preferences":                            211,
+	"Protocol":                               90,
+	"Proxy Protocol":                         151,
+	"Proxy already exists":                   182,
+	"Public Network":                         193,
+	"Quick Add":                              229,
+	"Random":                                 129,
+	"Re-enter password":                      225,
+	"Ready":                                  247,
+	"Relative":                               85,
+	"Remote Address":                         200,
+	"Remote Desktop":                         230,
+	"Remote Port":                            137,
+	"Rename automatically":                   246,
+	"Request headers":                        146,
+	"Retry Count":                            157,
+	"Retry Interval":                         159,
+	"Role":                                   131,
+	"Route User":                             148,
+	"Running":                                195,
 	"STUN Server":                            58,
 	"Scope":                                  65,
 	"Secret":                                 63,
-	"Secret Key":                             131,
-	"Select Certificate File":                104,
-	"Select Certificate Key File":            106,
-	"Select Log File":                        73,
-	"Select Trusted CA File":                 108,
-	"Select Unix Path":                       165,
-	"Select a folder for directory listing.": 167,
+	"Secret Key":                             134,
+	"Select Certificate File":                106,
+	"Select Certificate Key File":            108,
+	"Select Log File":                        74,
+	"Select Trusted CA File":                 110,
+	"Select Unix Path":                       169,
+	"Select a folder for directory listing.": 171,
 	"Select a local directory that the admin server will load resources from.": 81,
-	"Select language":                        215,
-	"Selection Required":                     253,
-	"Server":                                 129,
+	"Select language":                        219,
+	"Selection Required":                     258,
+	"Server":                                 132,
 	"Server Address":                         55,
-	"Server Name":                            138,
+	"Server Name":                            141,
 	"Server Port":                            56,
-	"Server User":                            139,
-	"Service":                                199,
-	"Set Defaults":                           218,
+	"Server User":                            142,
+	"Service":                                203,
+	"Set Defaults":                           222,
 	"Show in Folder":                         32,
-	"Source Address":                         112,
-	"Start":                                  198,
-	"Starting":                               193,
-	"Status":                                 195,
-	"Stop":                                   202,
-	"Stop config \"%s\"":                     200,
-	"Stopped":                                192,
-	"Stopping":                               194,
-	"Strip Prefix":                           168,
-	"Subdomain":                              140,
-	"TCP Mux":                                110,
+	"Source Address":                         115,
+	"Start":                                  202,
+	"Starting":                               197,
+	"Status":                                 199,
+	"Stop":                                   206,
+	"Stop config \"%s\"":                     204,
+	"Stopped":                                196,
+	"Stopping":                               198,
+	"Strip Prefix":                           172,
+	"Subdomain":                              143,
+	"TCP Mux":                                113,
 	"The config \"%s\" already removed.":     29,
-	"The config name \"%s\" already exists.": 123,
-	"The current display language is":        213,
-	"The file \"%s\" is not a valid ZIP file.":      48,
-	"The password is incorrect. Re-enter password.": 248,
-	"The proxy name \"%s\" already exists.":         179,
-	"The text does not match the required pattern.": 252,
-	"There are currently no updates available.":     22,
-	"Timeout":                 95,
-	"Times/Hour":              154,
+	"The config name \"%s\" already exists.": 126,
+	"The current display language is":        217,
+	"The file \"%s\" is not a valid ZIP file.":               48,
+	"The password is incorrect. Re-enter password.":          253,
+	"The proxy name \"%s\" already exists.":                  183,
+	"The text does not match the required pattern.":          257,
+	"There are currently no updates available.":              22,
+	"This feature only supports text in INI or TOML format.": 237,
+	"Timeout":                 97,
+	"Times/Hour":              158,
 	"Token":                   62,
 	"Token Endpoint":          66,
-	"Trusted CA":              107,
-	"Type":                    127,
-	"Unix Path":               164,
-	"Unknown":                 190,
-	"Use master password":     210,
-	"Use server SVCB records": 121,
+	"Trusted CA":              109,
+	"Type":                    130,
+	"UDP Packet Size":         93,
+	"Unix Path":               168,
+	"Unknown":                 194,
+	"Use master password":     214,
+	"Use server SVCB records": 123,
 	"User":                    57,
-	"Value":                   183,
+	"Value":                   187,
 	"Version: %s":             0,
-	"Visitor":                 130,
-	"Work Conns":              69,
-	"Yes":                     187,
-	"You can set a password to restrict access to this program.\nYou will be asked to enter it the next time you use this program.": 209,
-	"You must enter an administration password to operate the %s.":                                                                  246,
-	"You must restart program to apply the modification.":                                                                           214,
-	"auto":    148,
-	"default": 149,
-	"ms":      158,
-	"s":       94,
+	"Visitor":                 133,
+	"Work Conns":              70,
+	"Yes":                     191,
+	"You can set a password to restrict access to this program.\nYou will be asked to enter it the next time you use this program.": 213,
+	"You must enter an administration password to operate the %s.":                                                                  251,
+	"You must restart program to apply the modification.":                                                                           218,
+	"auto":    152,
+	"default": 153,
+	"ms":      162,
+	"s":       96,
 }
 
-var en_USIndex = []uint32{ // 257 elements
+var en_USIndex = []uint32{ // 262 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000f, 0x00000022, 0x00000032,
 	0x0000003c, 0x00000050, 0x00000062, 0x0000006c,
@@ -322,63 +327,64 @@ var en_USIndex = []uint32{ // 257 elements
 	0x000004c7, 0x000004d3, 0x000004d8, 0x000004de,
 	// Entry 40 - 5F
 	0x000004e5, 0x000004ee, 0x000004f4, 0x00000503,
-	0x00000512, 0x0000051e, 0x00000529, 0x0000052d,
-	0x0000056e, 0x00000577, 0x00000587, 0x0000058d,
-	0x00000596, 0x0000059c, 0x000005aa, 0x000005b5,
-	0x000005be, 0x000005c5, 0x0000060e, 0x0000061a,
-	0x00000623, 0x0000062c, 0x00000638, 0x00000644,
-	0x00000649, 0x00000654, 0x0000065d, 0x00000668,
-	0x00000673, 0x0000067d, 0x00000686, 0x00000688,
+	0x0000050e, 0x0000051d, 0x00000529, 0x00000534,
+	0x00000538, 0x00000579, 0x00000582, 0x00000592,
+	0x00000598, 0x000005a1, 0x000005a7, 0x000005b5,
+	0x000005be, 0x000005c5, 0x0000060e, 0x0000061c,
+	0x00000628, 0x00000631, 0x0000063a, 0x00000646,
+	0x00000652, 0x00000657, 0x00000662, 0x0000066b,
+	0x00000676, 0x00000681, 0x00000691, 0x0000069b,
 	// Entry 60 - 7F
-	0x00000690, 0x0000069d, 0x000006a7, 0x000006b4,
-	0x000006c0, 0x000006c3, 0x000006c7, 0x000006d1,
-	0x000006dd, 0x000006f5, 0x00000705, 0x00000721,
-	0x0000072c, 0x00000743, 0x0000074c, 0x00000754,
-	0x00000762, 0x00000771, 0x0000077f, 0x00000798,
-	0x000007b3, 0x000007ba, 0x000007d0, 0x000007df,
-	0x0000081e, 0x00000860, 0x00000878, 0x0000088e,
-	0x000008b6, 0x000008c0, 0x000008d3, 0x000008da,
+	0x000006a4, 0x000006a6, 0x000006ae, 0x000006bb,
+	0x000006c5, 0x000006d2, 0x000006de, 0x000006e1,
+	0x000006e5, 0x000006ef, 0x000006fb, 0x00000713,
+	0x00000723, 0x0000073f, 0x0000074a, 0x00000761,
+	0x0000077b, 0x00000784, 0x0000078c, 0x0000079a,
+	0x000007a9, 0x000007c2, 0x000007dd, 0x000007e6,
+	0x000007fc, 0x0000080b, 0x0000084a, 0x0000088c,
+	0x000008a4, 0x000008ae, 0x000008c4, 0x000008ec,
 	// Entry 80 - 9F
-	0x000008df, 0x000008e4, 0x000008eb, 0x000008f3,
-	0x000008fe, 0x0000090c, 0x00000917, 0x00000923,
-	0x0000092f, 0x0000093c, 0x00000946, 0x00000952,
-	0x0000095e, 0x00000968, 0x00000977, 0x00000981,
-	0x0000098d, 0x00000998, 0x0000099f, 0x000009a9,
-	0x000009b8, 0x000009bd, 0x000009c5, 0x000009d1,
-	0x000009dc, 0x000009e8, 0x000009f4, 0x000009ff,
-	0x00000a0e, 0x00000a17, 0x00000a28, 0x00000a2b,
+	0x000008f6, 0x00000909, 0x00000910, 0x00000915,
+	0x0000091a, 0x00000921, 0x00000929, 0x00000934,
+	0x00000942, 0x0000094d, 0x00000959, 0x00000965,
+	0x00000972, 0x0000097c, 0x00000988, 0x00000994,
+	0x0000099e, 0x000009ad, 0x000009b7, 0x000009c7,
+	0x000009d3, 0x000009de, 0x000009e5, 0x000009ef,
+	0x000009fe, 0x00000a03, 0x00000a0b, 0x00000a17,
+	0x00000a22, 0x00000a2e, 0x00000a3a, 0x00000a45,
 	// Entry A0 - BF
-	0x00000a35, 0x00000a43, 0x00000a50, 0x00000a57,
-	0x00000a63, 0x00000a6d, 0x00000a7e, 0x00000a89,
-	0x00000ab0, 0x00000abd, 0x00000aca, 0x00000ad0,
-	0x00000ada, 0x00000ae7, 0x00000af2, 0x00000b00,
-	0x00000b0e, 0x00000b1d, 0x00000b49, 0x00000b5e,
-	0x00000b85, 0x00000b95, 0x00000b9c, 0x00000ba1,
-	0x00000ba7, 0x00000bb0, 0x00000bb9, 0x00000bca,
-	0x00000bce, 0x00000bd1, 0x00000be0, 0x00000be8,
+	0x00000a54, 0x00000a5d, 0x00000a6e, 0x00000a71,
+	0x00000a7b, 0x00000a89, 0x00000a96, 0x00000a9d,
+	0x00000aa9, 0x00000ab3, 0x00000ac4, 0x00000acf,
+	0x00000af6, 0x00000b03, 0x00000b10, 0x00000b16,
+	0x00000b20, 0x00000b2d, 0x00000b38, 0x00000b46,
+	0x00000b54, 0x00000b63, 0x00000b8f, 0x00000ba4,
+	0x00000bcb, 0x00000bdb, 0x00000be2, 0x00000be7,
+	0x00000bed, 0x00000bf6, 0x00000bff, 0x00000c10,
 	// Entry C0 - DF
-	0x00000bf0, 0x00000bf8, 0x00000c01, 0x00000c0a,
-	0x00000c11, 0x00000c20, 0x00000c25, 0x00000c2b,
-	0x00000c33, 0x00000c47, 0x00000c7b, 0x00000c80,
-	0x00000c90, 0x00000c94, 0x00000c99, 0x00000ca3,
-	0x00000caf, 0x00000cbf, 0x00000d3c, 0x00000d50,
-	0x00000d60, 0x00000d6a, 0x00000d8a, 0x00000dbe,
-	0x00000dce, 0x00000dd7, 0x00000e4e, 0x00000e5b,
-	0x00000e6d, 0x00000e81, 0x00000e93, 0x00000ea4,
+	0x00000c14, 0x00000c17, 0x00000c26, 0x00000c2e,
+	0x00000c36, 0x00000c3e, 0x00000c47, 0x00000c50,
+	0x00000c57, 0x00000c66, 0x00000c6b, 0x00000c71,
+	0x00000c79, 0x00000c8d, 0x00000cc1, 0x00000cc6,
+	0x00000cd6, 0x00000cda, 0x00000cdf, 0x00000ce9,
+	0x00000cf5, 0x00000d05, 0x00000d82, 0x00000d96,
+	0x00000da6, 0x00000db0, 0x00000dd0, 0x00000e04,
+	0x00000e14, 0x00000e1d, 0x00000e94, 0x00000ea1,
 	// Entry E0 - FF
-	0x00000eae, 0x00000ebc, 0x00000ec6, 0x00000ed5,
-	0x00000ee6, 0x00000eed, 0x00000ef9, 0x00000f05,
-	0x00000f0d, 0x00000f21, 0x00000f36, 0x00000f6b,
-	0x00000f81, 0x00000fb7, 0x00000fbf, 0x00000fd2,
-	0x00000fde, 0x00001009, 0x0000101e, 0x00001024,
-	0x00001047, 0x00001050, 0x0000105f, 0x0000109f,
-	0x000010bd, 0x000010eb, 0x000010f9, 0x00001126,
-	0x00001151, 0x0000117f, 0x00001192, 0x000011bd,
+	0x00000eb3, 0x00000ec7, 0x00000ed9, 0x00000eea,
+	0x00000ef4, 0x00000f02, 0x00000f0c, 0x00000f1b,
+	0x00000f2c, 0x00000f33, 0x00000f3f, 0x00000f4b,
+	0x00000f53, 0x00000f67, 0x00000f9e, 0x00000fb3,
+	0x00000fe8, 0x00000ffe, 0x00001034, 0x0000103c,
+	0x0000104f, 0x0000105b, 0x00001086, 0x0000109b,
+	0x000010a1, 0x000010c4, 0x000010cd, 0x000010dc,
+	0x0000111c, 0x0000113a, 0x00001168, 0x00001176,
 	// Entry 100 - 11F
-	0x000011d6,
-} // Size: 1052 bytes
+	0x000011a3, 0x000011ce, 0x000011fc, 0x0000120f,
+	0x0000123a, 0x00001253,
+} // Size: 1072 bytes
 
-const en_USData string = "" + // Size: 4566 bytes
+const en_USData string = "" + // Size: 4691 bytes
 	"\x02Version: %[1]s\x02FRP version: %[1]s\x02Built on: %[1]s\x02All Files" +
 	"\x02Configuration Files\x02Certificate Files\x02Key Files\x02Log Files" +
 	"\x02Number out of allowed range\x02Please enter a number greater than %[" +
@@ -400,63 +406,65 @@ const en_USData string = "" + // Size: 4566 bytes
 	" config \x22%[1]s\x22?\x02New Client\x02Edit Client - %[1]s\x02Basic\x02" +
 	"Name\x02Server Address\x02Server Port\x02User\x02STUN Server\x02Auth\x02" +
 	"Auth Method\x02None\x02Token\x02Secret\x02Audience\x02Scope\x02Token End" +
-	"point\x02Authentication\x02Heart Beats\x02Work Conns\x02Log\x02* Leave b" +
-	"lank to record no log and delete the original log file.\x02Log File\x02S" +
-	"elect Log File\x02Level\x02Max Days\x02Admin\x02Admin Address\x02Admin P" +
-	"ort\x02Password\x02Assets\x02Select a local directory that the admin ser" +
-	"ver will load resources from.\x02Auto Delete\x02Absolute\x02Relative\x02" +
-	"Delete Date\x02Delete Days\x02Days\x02Connection\x02Protocol\x02HTTP Pro" +
-	"xy\x02Pool Count\x02Heartbeat\x02Interval\x02s\x02Timeout\x02Dial Timeou" +
-	"t\x02Keepalive\x02Idle Timeout\x02Max Streams\x02On\x02Off\x02Host Name" +
-	"\x02Certificate\x02Select Certificate File\x02Certificate Key\x02Select " +
-	"Certificate Key File\x02Trusted CA\x02Select Trusted CA File\x02Advanced" +
-	"\x02TCP Mux\x02Mux Keepalive\x02Source Address\x02Other Options\x02Exit " +
-	"after login failure\x02Disable auto-start at boot\x02Custom\x02Experimen" +
-	"tal Features\x02Custom Options\x02* Refer to the [common] section of the" +
-	" FRP configuration file.\x02* The following features may affect the stab" +
-	"ility of the service.\x02Use server SVCB records\x02Config already exist" +
-	"s\x02The config name \x22%[1]s\x22 already exists.\x02New Proxy\x02Edit " +
-	"Proxy - %[1]s\x02Random\x02Type\x02Role\x02Server\x02Visitor\x02Secret K" +
-	"ey\x02Local Address\x02Local Port\x02Remote Port\x02Allow Users\x02Bind " +
-	"Address\x02Bind Port\x02Server Name\x02Server User\x02Subdomain\x02Custo" +
-	"m Domains\x02Locations\x02Multiplexer\x02Route User\x02Client\x02Bandwid" +
-	"th\x02Proxy Protocol\x02auto\x02default\x02Keep Tunnel\x02Encryption\x02" +
-	"Compression\x02Retry Count\x02Times/Hour\x02Retry Interval\x02Fallback" +
-	"\x02Fallback Timeout\x02ms\x02HTTP User\x02HTTP Password\x02Host Rewrite" +
-	"\x02Plugin\x02Plugin Name\x02Unix Path\x02Select Unix Path\x02Local Path" +
-	"\x02Select a folder for directory listing.\x02Strip Prefix\x02Load Balan" +
-	"ce\x02Group\x02Group Key\x02Health Check\x02Check Type\x02Check Timeout" +
-	"\x02Failure Count\x02Check Interval\x02* Refer to the parameters support" +
-	"ed by FRP.\x02Proxy already exists\x02The proxy name \x22%[1]s\x22 alrea" +
-	"dy exists.\x02Open Log Folder\x02Latest\x02Item\x02Value\x02NAT Type\x02" +
-	"Behavior\x02External Address\x02Yes\x02No\x02Public Network\x02Unknown" +
-	"\x02Running\x02Stopped\x02Starting\x02Stopping\x02Status\x02Remote Addre" +
-	"ss\x02Copy\x02Start\x02Service\x02Stop config \x22%[1]s\x22\x02Are you s" +
-	"ure you would like to stop config \x22%[1]s\x22?\x02Stop\x02Local Direct" +
-	"ory\x02Add\x02Port\x02Open Port\x02Preferences\x02Master password\x02You" +
-	" can set a password to restrict access to this program.\x0aYou will be a" +
-	"sked to enter it the next time you use this program.\x02Use master passw" +
-	"ord\x02Change Password\x02Languages\x02The current display language is" +
-	"\x02You must restart program to apply the modification.\x02Select langua" +
-	"ge\x02Defaults\x02Define the default value when creating a new configura" +
-	"tion.\x0aThe value here will not affect the existing configuration.\x02S" +
-	"et Defaults\x02Password removed.\x02New master password\x02Re-enter pass" +
-	"word\x02Password is set.\x02Log Level\x02Log retention\x02Quick Add\x02R" +
-	"emote Desktop\x02HTTP File Server\x02Enable\x02Open Config\x02Direct Edi" +
-	"t\x02Domains\x02Copy Access Address\x02Delete proxy \x22%[1]s\x22\x02Are" +
-	" you sure you would like to delete proxy \x22%[1]s\x22?\x02Disable proxy" +
-	" \x22%[1]s\x22\x02Are you sure you would like to disable proxy \x22%[1]s" +
-	"\x22?\x02Disable\x02Passive Port Range\x02FRP Manager\x02* Support batch" +
-	" import, one link per line.\x02Rename automatically\x02Ready\x02Please e" +
-	"nter the correct URL list.\x02Download\x02Enter Password\x02You must ent" +
-	"er an administration password to operate the %[1]s.\x02Enter Administrat" +
-	"ion Password\x02The password is incorrect. Re-enter password.\x02Invalid" +
-	" Input\x02Please enter a number from %.[1]f to %.[2]f.\x02Please enter a" +
-	" number from %[1]s to %[2]s.\x02The text does not match the required pat" +
-	"tern.\x02Selection Required\x02Please select one of the provided options" +
-	".\x02A selection is required."
+	"point\x02Parameters\x02Authentication\x02Heart Beats\x02Work Conns\x02Lo" +
+	"g\x02* Leave blank to record no log and delete the original log file." +
+	"\x02Log File\x02Select Log File\x02Level\x02Max Days\x02Admin\x02Admin A" +
+	"ddress\x02Password\x02Assets\x02Select a local directory that the admin " +
+	"server will load resources from.\x02Other Options\x02Auto Delete\x02Abso" +
+	"lute\x02Relative\x02Delete Date\x02Delete Days\x02Days\x02Connection\x02" +
+	"Protocol\x02HTTP Proxy\x02Pool Count\x02UDP Packet Size\x02Heartbeat\x02" +
+	"Interval\x02s\x02Timeout\x02Dial Timeout\x02Keepalive\x02Idle Timeout" +
+	"\x02Max Streams\x02On\x02Off\x02Host Name\x02Certificate\x02Select Certi" +
+	"ficate File\x02Certificate Key\x02Select Certificate Key File\x02Trusted" +
+	" CA\x02Select Trusted CA File\x02Disable custom first byte\x02Advanced" +
+	"\x02TCP Mux\x02Mux Keepalive\x02Source Address\x02Exit after login failu" +
+	"re\x02Disable auto-start at boot\x02Metadata\x02Experimental Features" +
+	"\x02Custom Options\x02* Refer to the [common] section of the FRP configu" +
+	"ration file.\x02* The following features may affect the stability of the" +
+	" service.\x02Use server SVCB records\x02Clear All\x02Config already exis" +
+	"ts\x02The config name \x22%[1]s\x22 already exists.\x02New Proxy\x02Edit" +
+	" Proxy - %[1]s\x02Random\x02Type\x02Role\x02Server\x02Visitor\x02Secret " +
+	"Key\x02Local Address\x02Local Port\x02Remote Port\x02Allow Users\x02Bind" +
+	" Address\x02Bind Port\x02Server Name\x02Server User\x02Subdomain\x02Cust" +
+	"om Domains\x02Locations\x02Request headers\x02Multiplexer\x02Route User" +
+	"\x02Client\x02Bandwidth\x02Proxy Protocol\x02auto\x02default\x02Keep Tun" +
+	"nel\x02Encryption\x02Compression\x02Retry Count\x02Times/Hour\x02Retry I" +
+	"nterval\x02Fallback\x02Fallback Timeout\x02ms\x02HTTP User\x02HTTP Passw" +
+	"ord\x02Host Rewrite\x02Plugin\x02Plugin Name\x02Unix Path\x02Select Unix" +
+	" Path\x02Local Path\x02Select a folder for directory listing.\x02Strip P" +
+	"refix\x02Load Balance\x02Group\x02Group Key\x02Health Check\x02Check Typ" +
+	"e\x02Check Timeout\x02Failure Count\x02Check Interval\x02* Refer to the " +
+	"parameters supported by FRP.\x02Proxy already exists\x02The proxy name " +
+	"\x22%[1]s\x22 already exists.\x02Open Log Folder\x02Latest\x02Item\x02Va" +
+	"lue\x02NAT Type\x02Behavior\x02External Address\x02Yes\x02No\x02Public N" +
+	"etwork\x02Unknown\x02Running\x02Stopped\x02Starting\x02Stopping\x02Statu" +
+	"s\x02Remote Address\x02Copy\x02Start\x02Service\x02Stop config \x22%[1]s" +
+	"\x22\x02Are you sure you would like to stop config \x22%[1]s\x22?\x02Sto" +
+	"p\x02Local Directory\x02Add\x02Port\x02Open Port\x02Preferences\x02Maste" +
+	"r password\x02You can set a password to restrict access to this program." +
+	"\x0aYou will be asked to enter it the next time you use this program." +
+	"\x02Use master password\x02Change Password\x02Languages\x02The current d" +
+	"isplay language is\x02You must restart program to apply the modification" +
+	".\x02Select language\x02Defaults\x02Define the default value when creati" +
+	"ng a new configuration.\x0aThe value here will not affect the existing c" +
+	"onfiguration.\x02Set Defaults\x02Password removed.\x02New master passwor" +
+	"d\x02Re-enter password\x02Password is set.\x02Log Level\x02Log retention" +
+	"\x02Quick Add\x02Remote Desktop\x02HTTP File Server\x02Enable\x02Open Co" +
+	"nfig\x02Direct Edit\x02Domains\x02Copy Access Address\x02This feature on" +
+	"ly supports text in INI or TOML format.\x02Delete proxy \x22%[1]s\x22" +
+	"\x02Are you sure you would like to delete proxy \x22%[1]s\x22?\x02Disabl" +
+	"e proxy \x22%[1]s\x22\x02Are you sure you would like to disable proxy " +
+	"\x22%[1]s\x22?\x02Disable\x02Passive Port Range\x02FRP Manager\x02* Supp" +
+	"ort batch import, one link per line.\x02Rename automatically\x02Ready" +
+	"\x02Please enter the correct URL list.\x02Download\x02Enter Password\x02" +
+	"You must enter an administration password to operate the %[1]s.\x02Enter" +
+	" Administration Password\x02The password is incorrect. Re-enter password" +
+	".\x02Invalid Input\x02Please enter a number from %.[1]f to %.[2]f.\x02Pl" +
+	"ease enter a number from %[1]s to %[2]s.\x02The text does not match the " +
+	"required pattern.\x02Selection Required\x02Please select one of the prov" +
+	"ided options.\x02A selection is required."
 
-var es_ESIndex = []uint32{ // 257 elements
+var es_ESIndex = []uint32{ // 262 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000010, 0x00000024, 0x00000041,
 	0x00000054, 0x0000006f, 0x00000087, 0x00000096,
@@ -477,63 +485,64 @@ var es_ESIndex = []uint32{ // 257 elements
 	0x00000605, 0x0000060d, 0x00000615, 0x00000620,
 	// Entry 40 - 5F
 	0x00000628, 0x00000632, 0x0000063a, 0x0000064e,
-	0x0000065d, 0x00000672, 0x00000687, 0x00000690,
-	0x000006f3, 0x00000707, 0x00000727, 0x0000072d,
-	0x0000073c, 0x00000742, 0x0000074d, 0x00000754,
-	0x0000075a, 0x00000762, 0x000007c4, 0x000007dd,
-	0x000007e6, 0x000007ef, 0x000007fe, 0x0000080d,
-	0x00000813, 0x0000081d, 0x00000827, 0x00000832,
-	0x00000842, 0x00000856, 0x00000860, 0x00000862,
+	0x0000065a, 0x00000669, 0x0000067e, 0x00000693,
+	0x0000069c, 0x000006ff, 0x00000713, 0x00000733,
+	0x00000739, 0x00000748, 0x0000074e, 0x00000759,
+	0x0000075f, 0x00000767, 0x000007c9, 0x000007d8,
+	0x000007f1, 0x000007fa, 0x00000803, 0x00000812,
+	0x00000821, 0x00000827, 0x00000831, 0x0000083b,
+	0x00000846, 0x00000856, 0x0000086e, 0x00000882,
 	// Entry 60 - 7F
-	0x00000870, 0x00000882, 0x0000088c, 0x000008a2,
-	0x000008b6, 0x000008bf, 0x000008c7, 0x000008dc,
-	0x000008e8, 0x0000090b, 0x00000920, 0x0000094c,
-	0x0000095c, 0x00000980, 0x00000989, 0x00000991,
-	0x0000099f, 0x000009b7, 0x000009c6, 0x000009f4,
-	0x00000a21, 0x00000a29, 0x00000a49, 0x00000a61,
-	0x00000aa7, 0x00000af5, 0x00000b16, 0x00000b32,
-	0x00000b61, 0x00000b6d, 0x00000b82, 0x00000b8c,
+	0x0000088c, 0x0000088e, 0x0000089c, 0x000008ae,
+	0x000008b8, 0x000008ce, 0x000008e2, 0x000008eb,
+	0x000008f3, 0x00000908, 0x00000914, 0x00000937,
+	0x0000094c, 0x00000978, 0x00000988, 0x000009ac,
+	0x000009d1, 0x000009da, 0x000009e2, 0x000009f0,
+	0x00000a08, 0x00000a36, 0x00000a63, 0x00000a6d,
+	0x00000a8d, 0x00000aa5, 0x00000aeb, 0x00000b39,
+	0x00000b5a, 0x00000b67, 0x00000b83, 0x00000bb2,
 	// Entry 80 - 9F
-	0x00000b91, 0x00000b96, 0x00000b9f, 0x00000ba9,
-	0x00000bb7, 0x00000bc8, 0x00000bd5, 0x00000be3,
-	0x00000bf5, 0x00000c0a, 0x00000c1b, 0x00000c2f,
-	0x00000c44, 0x00000c4f, 0x00000c67, 0x00000c70,
-	0x00000c7c, 0x00000c8c, 0x00000c94, 0x00000ca0,
-	0x00000cb0, 0x00000cb5, 0x00000cc1, 0x00000cd1,
-	0x00000cd9, 0x00000ce5, 0x00000cfb, 0x00000d06,
-	0x00000d1d, 0x00000d26, 0x00000d3e, 0x00000d4a,
+	0x00000bbe, 0x00000bd3, 0x00000bdd, 0x00000be2,
+	0x00000be7, 0x00000bf0, 0x00000bfa, 0x00000c08,
+	0x00000c19, 0x00000c26, 0x00000c34, 0x00000c46,
+	0x00000c5b, 0x00000c6c, 0x00000c80, 0x00000c95,
+	0x00000ca0, 0x00000cb8, 0x00000cc1, 0x00000cd7,
+	0x00000ce3, 0x00000cf3, 0x00000cfb, 0x00000d07,
+	0x00000d17, 0x00000d1c, 0x00000d28, 0x00000d38,
+	0x00000d40, 0x00000d4c, 0x00000d62, 0x00000d6d,
 	// Entry A0 - BF
-	0x00000d57, 0x00000d68, 0x00000d7c, 0x00000d85,
-	0x00000d8c, 0x00000d96, 0x00000db1, 0x00000dbc,
-	0x00000df1, 0x00000e01, 0x00000e15, 0x00000e1b,
-	0x00000e2a, 0x00000e3b, 0x00000e40, 0x00000e54,
-	0x00000e67, 0x00000e71, 0x00000e9f, 0x00000eb2,
-	0x00000ed8, 0x00000ee7, 0x00000eef, 0x00000ef5,
-	0x00000eff, 0x00000f0b, 0x00000f1a, 0x00000f2d,
-	0x00000f31, 0x00000f34, 0x00000f41, 0x00000f4d,
+	0x00000d84, 0x00000d8d, 0x00000da5, 0x00000db1,
+	0x00000dbe, 0x00000dcf, 0x00000de3, 0x00000dec,
+	0x00000df3, 0x00000dfd, 0x00000e18, 0x00000e23,
+	0x00000e58, 0x00000e68, 0x00000e7c, 0x00000e82,
+	0x00000e91, 0x00000ea2, 0x00000ea7, 0x00000ebb,
+	0x00000ece, 0x00000ed8, 0x00000f06, 0x00000f19,
+	0x00000f3f, 0x00000f4e, 0x00000f56, 0x00000f5c,
+	0x00000f66, 0x00000f72, 0x00000f81, 0x00000f94,
 	// Entry C0 - DF
-	0x00000f54, 0x00000f5d, 0x00000f68, 0x00000f6f,
-	0x00000f76, 0x00000f88, 0x00000f8f, 0x00000f98,
-	0x00000fa1, 0x00000fc0, 0x00000fff, 0x0000100a,
-	0x0000101b, 0x00001023, 0x0000102a, 0x00001039,
-	0x00001046, 0x0000105a, 0x000010ea, 0x00001103,
-	0x0000111a, 0x00001122, 0x00001148, 0x00001182,
-	0x00001197, 0x000011a7, 0x00001222, 0x00001231,
-	0x00001248, 0x00001262, 0x00001282, 0x000012a4,
+	0x00000f98, 0x00000f9b, 0x00000fa8, 0x00000fb4,
+	0x00000fbb, 0x00000fc4, 0x00000fcf, 0x00000fd6,
+	0x00000fdd, 0x00000fef, 0x00000ff6, 0x00000fff,
+	0x00001008, 0x00001027, 0x00001066, 0x00001071,
+	0x00001082, 0x0000108a, 0x00001091, 0x000010a0,
+	0x000010ad, 0x000010c1, 0x00001151, 0x0000116a,
+	0x00001181, 0x00001189, 0x000011af, 0x000011e9,
+	0x000011fe, 0x0000120e, 0x00001289, 0x00001298,
 	// Entry E0 - FF
-	0x000012b6, 0x000012ce, 0x000012de, 0x000012f0,
-	0x0000130a, 0x00001314, 0x00001329, 0x0000133a,
-	0x00001343, 0x0000135f, 0x00001376, 0x000013ad,
-	0x000013c8, 0x00001401, 0x0000140e, 0x00001426,
-	0x0000143b, 0x00001472, 0x0000148d, 0x00001493,
-	0x000014b8, 0x000014c2, 0x000014dc, 0x00001520,
-	0x0000154a, 0x00001589, 0x0000159a, 0x000015c1,
-	0x000015e6, 0x00001615, 0x0000162a, 0x00001659,
+	0x000012af, 0x000012c9, 0x000012e9, 0x0000130b,
+	0x0000131d, 0x00001335, 0x00001345, 0x00001357,
+	0x00001371, 0x0000137b, 0x00001390, 0x000013a1,
+	0x000013aa, 0x000013c6, 0x000013fd, 0x00001414,
+	0x0000144b, 0x00001466, 0x0000149f, 0x000014ac,
+	0x000014c4, 0x000014d9, 0x00001510, 0x0000152b,
+	0x00001531, 0x00001556, 0x00001560, 0x0000157a,
+	0x000015be, 0x000015e8, 0x00001627, 0x00001638,
 	// Entry 100 - 11F
-	0x00001675,
-} // Size: 1052 bytes
+	0x0000165f, 0x00001684, 0x000016b3, 0x000016c8,
+	0x000016f7, 0x00001713,
+} // Size: 1072 bytes
 
-const es_ESData string = "" + // Size: 5749 bytes
+const es_ESData string = "" + // Size: 5907 bytes
 	"\x02Versión: %[1]s\x02Versión FRP: %[1]s\x02Fecha de compilación: %[1]s" +
 	"\x02Todos los archivos\x02Archivos de configuración\x02Archivos de certi" +
 	"ficado\x02Archivos clave\x02Archivos de registro\x02Número fuera del ran" +
@@ -559,74 +568,76 @@ const es_ESData string = "" + // Size: 5749 bytes
 	" Cliente\x02Editar Cliente - %[1]s\x02Básico\x02Nombre\x02Dirección del " +
 	"servidor\x02Puerto de servicio\x02Usuario\x02Servidor STUN\x02Auth\x02Mé" +
 	"todo\x02Ninguna\x02Simbólico\x02Secreto\x02Audiencia\x02Alcance\x02Direc" +
-	"ción de token\x02Autenticación\x02Latidos del corazón\x02Conexión de tra" +
-	"bajo\x02Registro\x02* Déjelo en blanco para no registrar ningún registro" +
-	" y eliminar el archivo de registro original.\x02Archivo de registro\x02S" +
-	"eleccionar archivo de registro\x02Nivel\x02Días máximos\x02Admin\x02Dire" +
-	"cción\x02Puerto\x02Clave\x02Recurso\x02Seleccione un directorio local de" +
-	"sde el que el servidor de administración cargará los recursos.\x02Elimin" +
-	"ación automática\x02Absoluto\x02Relativo\x02Eliminar fecha\x02Eliminar d" +
-	"ías\x02Días\x02Conexión\x02Protocolo\x02Proxy HTTP\x02Conectar cuenta" +
-	"\x02Latido del corazón\x02Intervalo\x02s\x02Tiempo muerto\x02Conexión ag" +
-	"otado\x02Keepalive\x02Tiempo de inactividad\x02Corrientes máximas\x02Enc" +
-	"ender\x02Apagado\x02Nombre de anfitrión\x02Certificado\x02Seleccionar ar" +
-	"chivo de certificado\x02Clave de certificado\x02Seleccionar archivo de c" +
-	"lave de certificado\x02CA de confianza\x02Seleccionar archivo CA de conf" +
-	"ianza\x02Avanzado\x02Mux TCP\x02Mux Keepalive\x02Dirección de la fuente" +
-	"\x02Otras opciones\x02Salir después de fallar el inicio de sesión\x02Des" +
-	"activar el inicio automático al arrancar\x02Disfraz\x02Características e" +
-	"xperimentales\x02Opciones personalizadas\x02* Consulte la sección [commo" +
-	"n] del archivo de configuración de FRP.\x02* Las siguientes característi" +
-	"cas pueden afectar la estabilidad del servicio.\x02Usar registros SVCB d" +
-	"el servidor\x02La configuración ya existe\x02El nombre de configuración " +
-	"\x22%[1]s\x22 ya existe.\x02Nuevo Proxy\x02Editar Proxy - %[1]s\x02Aleat" +
-	"orio\x02Tipo\x02Role\x02Servidor\x02Visitante\x02Llave secreta\x02Direcc" +
-	"ión local\x02Puerto local\x02Puerto remoto\x02Permitir usuarios\x02Direc" +
-	"ción de enlace\x02Puerto de enlace\x02Nombre del servidor\x02Usuario del" +
-	" servidor\x02Subdominio\x02Dominios personalizados\x02Ruta URL\x02Multip" +
-	"lexor\x02Usuario de ruta\x02Cliente\x02Banda ancha\x02Protocolo proxy" +
-	"\x02auto\x02por defecto\x02Mantener túnel\x02Cifrado\x02Compresión\x02Nú" +
-	"mero de reintentos\x02Veces/Hora\x02Intervalo de reintento\x02Repuesto" +
-	"\x02Interruptor de respaldo\x02milisegundo\x02Usuario HTTP\x02Contraseña" +
-	" HTTP\x02Reescritura de host\x02Enchufar\x02Nombre\x02Ruta Unix\x02Selec" +
-	"cione la ruta de Unix\x02Ruta local\x02Seleccione una carpeta para la li" +
-	"sta de directorios.\x02Prefijo de tira\x02Equilibrio de carga\x02Grupo" +
-	"\x02Clave de grupo\x02Chequeo de salud\x02Tipo\x02Se acabó el tiempo\x02" +
-	"Recuento de fallas\x02Intervalo\x02* Consulte los parámetros admitidos p" +
-	"or FRP.\x02El proxy ya existe\x02El nombre de proxy \x22%[1]s\x22 ya exi" +
-	"ste.\x02Abrir registro\x02Último\x02Ítem\x02Valorizar\x02Tipo de NAT\x02" +
-	"Comportamiento\x02Dirección externa\x02Sí\x02No\x02Red pública\x02Descon" +
-	"ocido\x02Correr\x02Detenido\x02Comenzando\x02Parada\x02Estado\x02Direcci" +
-	"ón remota\x02Copiar\x02Comienzo\x02Servicio\x02Detener configuración " +
-	"\x22%[1]s\x22\x02¿Está seguro de que desea detener la configuración \x22" +
-	"%[1]s\x22?\x02Deténgase\x02Directorio local\x02Agregar\x02Puerto\x02Puer" +
-	"to abierto\x02Preferencias\x02Contraseña maestra\x02Puede establecer una" +
-	" contraseña para restringir el acceso a este programa.\x0aSe le pedirá q" +
-	"ue lo ingrese la próxima vez que use este programa.\x02Usar contraseña m" +
-	"aestra\x02Cambiar la contraseña\x02Idiomas\x02El idioma de visualización" +
-	" actual es\x02Debe reiniciar el programa para aplicar la modificación." +
-	"\x02Seleccione el idioma\x02Predeterminados\x02Defina el valor predeterm" +
-	"inado al crear una nueva configuración.\x0aEl valor aquí no afectará la " +
-	"configuración existente.\x02Valor ajustado\x02Contraseña eliminada.\x02N" +
-	"ueva contraseña maestra\x02Escriba la contraseña otra vez\x02La contrase" +
-	"ña está configurada.\x02Nivel de registro\x02Retención de registros\x02" +
-	"Añadir rápido\x02Escritorio remoto\x02Servidor de archivos HTTP\x02Habil" +
-	"itar\x02Abrir configuración\x02Edición directa\x02Dominios\x02Copiar dir" +
-	"ección de acceso\x02Eliminar proxy \x22%[1]s\x22\x02¿Está seguro de que " +
-	"desea eliminar el proxy \x22%[1]s\x22?\x02Deshabilitar proxy \x22%[1]s" +
-	"\x22\x02¿Está seguro de que desea desactivar el proxy \x22%[1]s\x22?\x02" +
-	"Deshabilitar\x02Gama de puertos pasivos\x02Administrador de FRP\x02* Adm" +
-	"ite importación por lotes, un enlace por línea.\x02Renombrar automáticam" +
-	"ente\x02Listo\x02Introduzca la lista de URL correcta.\x02Descargar\x02In" +
-	"troducir la contraseña\x02Debe ingresar una contraseña de administración" +
-	" para operar %[1]s.\x02Ingrese la contraseña de administración\x02La con" +
-	"traseña es incorrecta. Escriba la contraseña otra vez.\x02Entrada invali" +
-	"da\x02Ingrese un número de %.[1]f a %.[2]f.\x02Ingrese un número de %[1]" +
-	"s a %[2]s.\x02El texto no coincide con el patrón requerido.\x02Selección" +
-	" requerida\x02Seleccione una de las opciones proporcionadas.\x02Se requi" +
-	"ere una selección."
+	"ción de token\x02Parámetros\x02Autenticación\x02Latidos del corazón\x02C" +
+	"onexión de trabajo\x02Registro\x02* Déjelo en blanco para no registrar n" +
+	"ingún registro y eliminar el archivo de registro original.\x02Archivo de" +
+	" registro\x02Seleccionar archivo de registro\x02Nivel\x02Días máximos" +
+	"\x02Admin\x02Dirección\x02Clave\x02Recurso\x02Seleccione un directorio l" +
+	"ocal desde el que el servidor de administración cargará los recursos." +
+	"\x02Otras opciones\x02Eliminación automática\x02Absoluto\x02Relativo\x02" +
+	"Eliminar fecha\x02Eliminar días\x02Días\x02Conexión\x02Protocolo\x02Prox" +
+	"y HTTP\x02Conectar cuenta\x02Tamaño del paquete UDP\x02Latido del corazó" +
+	"n\x02Intervalo\x02s\x02Tiempo muerto\x02Conexión agotado\x02Keepalive" +
+	"\x02Tiempo de inactividad\x02Corrientes máximas\x02Encender\x02Apagado" +
+	"\x02Nombre de anfitrión\x02Certificado\x02Seleccionar archivo de certifi" +
+	"cado\x02Clave de certificado\x02Seleccionar archivo de clave de certific" +
+	"ado\x02CA de confianza\x02Seleccionar archivo CA de confianza\x02Desacti" +
+	"var primer byte personalizado\x02Avanzado\x02Mux TCP\x02Mux Keepalive" +
+	"\x02Dirección de la fuente\x02Salir después de fallar el inicio de sesió" +
+	"n\x02Desactivar el inicio automático al arrancar\x02Metadatos\x02Caracte" +
+	"rísticas experimentales\x02Opciones personalizadas\x02* Consulte la secc" +
+	"ión [common] del archivo de configuración de FRP.\x02* Las siguientes ca" +
+	"racterísticas pueden afectar la estabilidad del servicio.\x02Usar regist" +
+	"ros SVCB del servidor\x02Limpiar todo\x02La configuración ya existe\x02E" +
+	"l nombre de configuración \x22%[1]s\x22 ya existe.\x02Nuevo Proxy\x02Edi" +
+	"tar Proxy - %[1]s\x02Aleatorio\x02Tipo\x02Role\x02Servidor\x02Visitante" +
+	"\x02Llave secreta\x02Dirección local\x02Puerto local\x02Puerto remoto" +
+	"\x02Permitir usuarios\x02Dirección de enlace\x02Puerto de enlace\x02Nomb" +
+	"re del servidor\x02Usuario del servidor\x02Subdominio\x02Dominios person" +
+	"alizados\x02Ruta URL\x02Solicitar encabezados\x02Multiplexor\x02Usuario " +
+	"de ruta\x02Cliente\x02Banda ancha\x02Protocolo proxy\x02auto\x02por defe" +
+	"cto\x02Mantener túnel\x02Cifrado\x02Compresión\x02Número de reintentos" +
+	"\x02Veces/Hora\x02Intervalo de reintento\x02Repuesto\x02Interruptor de r" +
+	"espaldo\x02milisegundo\x02Usuario HTTP\x02Contraseña HTTP\x02Reescritura" +
+	" de host\x02Enchufar\x02Nombre\x02Ruta Unix\x02Seleccione la ruta de Uni" +
+	"x\x02Ruta local\x02Seleccione una carpeta para la lista de directorios." +
+	"\x02Prefijo de tira\x02Equilibrio de carga\x02Grupo\x02Clave de grupo" +
+	"\x02Chequeo de salud\x02Tipo\x02Se acabó el tiempo\x02Recuento de fallas" +
+	"\x02Intervalo\x02* Consulte los parámetros admitidos por FRP.\x02El prox" +
+	"y ya existe\x02El nombre de proxy \x22%[1]s\x22 ya existe.\x02Abrir regi" +
+	"stro\x02Último\x02Ítem\x02Valorizar\x02Tipo de NAT\x02Comportamiento\x02" +
+	"Dirección externa\x02Sí\x02No\x02Red pública\x02Desconocido\x02Correr" +
+	"\x02Detenido\x02Comenzando\x02Parada\x02Estado\x02Dirección remota\x02Co" +
+	"piar\x02Comienzo\x02Servicio\x02Detener configuración \x22%[1]s\x22\x02¿" +
+	"Está seguro de que desea detener la configuración \x22%[1]s\x22?\x02Deté" +
+	"ngase\x02Directorio local\x02Agregar\x02Puerto\x02Puerto abierto\x02Pref" +
+	"erencias\x02Contraseña maestra\x02Puede establecer una contraseña para r" +
+	"estringir el acceso a este programa.\x0aSe le pedirá que lo ingrese la p" +
+	"róxima vez que use este programa.\x02Usar contraseña maestra\x02Cambiar " +
+	"la contraseña\x02Idiomas\x02El idioma de visualización actual es\x02Debe" +
+	" reiniciar el programa para aplicar la modificación.\x02Seleccione el id" +
+	"ioma\x02Predeterminados\x02Defina el valor predeterminado al crear una n" +
+	"ueva configuración.\x0aEl valor aquí no afectará la configuración existe" +
+	"nte.\x02Valor ajustado\x02Contraseña eliminada.\x02Nueva contraseña maes" +
+	"tra\x02Escriba la contraseña otra vez\x02La contraseña está configurada." +
+	"\x02Nivel de registro\x02Retención de registros\x02Añadir rápido\x02Escr" +
+	"itorio remoto\x02Servidor de archivos HTTP\x02Habilitar\x02Abrir configu" +
+	"ración\x02Edición directa\x02Dominios\x02Copiar dirección de acceso\x02E" +
+	"sta función solo admite texto en formato INI o TOML.\x02Eliminar proxy " +
+	"\x22%[1]s\x22\x02¿Está seguro de que desea eliminar el proxy \x22%[1]s" +
+	"\x22?\x02Deshabilitar proxy \x22%[1]s\x22\x02¿Está seguro de que desea d" +
+	"esactivar el proxy \x22%[1]s\x22?\x02Deshabilitar\x02Gama de puertos pas" +
+	"ivos\x02Administrador de FRP\x02* Admite importación por lotes, un enlac" +
+	"e por línea.\x02Renombrar automáticamente\x02Listo\x02Introduzca la list" +
+	"a de URL correcta.\x02Descargar\x02Introducir la contraseña\x02Debe ingr" +
+	"esar una contraseña de administración para operar %[1]s.\x02Ingrese la c" +
+	"ontraseña de administración\x02La contraseña es incorrecta. Escriba la c" +
+	"ontraseña otra vez.\x02Entrada invalida\x02Ingrese un número de %.[1]f a" +
+	" %.[2]f.\x02Ingrese un número de %[1]s a %[2]s.\x02El texto no coincide " +
+	"con el patrón requerido.\x02Selección requerida\x02Seleccione una de las" +
+	" opciones proporcionadas.\x02Se requiere una selección."
 
-var ja_JPIndex = []uint32{ // 257 elements
+var ja_JPIndex = []uint32{ // 262 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000018, 0x00000034, 0x0000004f,
 	0x00000068, 0x0000007b, 0x00000091, 0x000000a7,
@@ -647,63 +658,64 @@ var ja_JPIndex = []uint32{ // 257 elements
 	0x00000761, 0x0000076e, 0x00000775, 0x00000782,
 	// Entry 40 - 5F
 	0x0000078c, 0x00000796, 0x0000079d, 0x000007b0,
-	0x000007b7, 0x000007c7, 0x000007d4, 0x000007db,
-	0x00000844, 0x00000857, 0x00000873, 0x0000087d,
-	0x0000088a, 0x00000894, 0x000008aa, 0x000008ba,
-	0x000008ca, 0x000008d1, 0x00000938, 0x00000945,
-	0x0000094c, 0x00000953, 0x0000095d, 0x0000096a,
-	0x0000096e, 0x00000975, 0x00000985, 0x00000997,
-	0x000009ad, 0x000009c0, 0x000009c7, 0x000009c9,
+	0x000007c3, 0x000007ca, 0x000007da, 0x000007e7,
+	0x000007ee, 0x00000857, 0x0000086a, 0x00000886,
+	0x00000890, 0x0000089d, 0x000008a7, 0x000008bd,
+	0x000008cd, 0x000008d4, 0x0000093b, 0x00000951,
+	0x0000095e, 0x00000965, 0x0000096c, 0x00000976,
+	0x00000983, 0x00000987, 0x0000098e, 0x0000099e,
+	0x000009b0, 0x000009c6, 0x000009df, 0x000009f2,
 	// Entry 60 - 7F
-	0x000009dc, 0x000009f5, 0x00000a05, 0x00000a24,
-	0x00000a3a, 0x00000a41, 0x00000a48, 0x00000a55,
-	0x00000a5f, 0x00000a7e, 0x00000a8e, 0x00000abc,
-	0x00000acf, 0x00000b01, 0x00000b08, 0x00000b12,
-	0x00000b2b, 0x00000b41, 0x00000b57, 0x00000b76,
-	0x00000ba1, 0x00000bae, 0x00000bc1, 0x00000bdd,
-	0x00000c30, 0x00000c8d, 0x00000cb9, 0x00000cdb,
-	0x00000d0e, 0x00000d24, 0x00000d42, 0x00000d4f,
+	0x000009f9, 0x000009fb, 0x00000a0e, 0x00000a27,
+	0x00000a37, 0x00000a56, 0x00000a6c, 0x00000a73,
+	0x00000a7a, 0x00000a87, 0x00000a91, 0x00000ab0,
+	0x00000ac0, 0x00000aee, 0x00000b01, 0x00000b33,
+	0x00000b64, 0x00000b6b, 0x00000b75, 0x00000b8e,
+	0x00000ba4, 0x00000bc3, 0x00000bee, 0x00000bfe,
+	0x00000c11, 0x00000c2d, 0x00000c80, 0x00000cdd,
+	0x00000d09, 0x00000d1c, 0x00000d3e, 0x00000d71,
 	// Entry 80 - 9F
-	0x00000d59, 0x00000d60, 0x00000d6a, 0x00000d77,
-	0x00000d81, 0x00000d9a, 0x00000db0, 0x00000dc6,
-	0x00000de2, 0x00000dfb, 0x00000e11, 0x00000e21,
-	0x00000e3a, 0x00000e4d, 0x00000e66, 0x00000e7d,
-	0x00000e93, 0x00000ea9, 0x00000ebc, 0x00000ec6,
-	0x00000ee2, 0x00000ee9, 0x00000ef3, 0x00000f0f,
-	0x00000f19, 0x00000f20, 0x00000f33, 0x00000f3e,
-	0x00000f4e, 0x00000f55, 0x00000f7d, 0x00000f87,
+	0x00000d87, 0x00000da5, 0x00000db2, 0x00000dbc,
+	0x00000dc3, 0x00000dcd, 0x00000dda, 0x00000de4,
+	0x00000dfd, 0x00000e13, 0x00000e29, 0x00000e45,
+	0x00000e5e, 0x00000e74, 0x00000e84, 0x00000e9d,
+	0x00000eb0, 0x00000ec9, 0x00000ee0, 0x00000efc,
+	0x00000f12, 0x00000f28, 0x00000f3b, 0x00000f45,
+	0x00000f61, 0x00000f68, 0x00000f72, 0x00000f8e,
+	0x00000f98, 0x00000f9f, 0x00000fb2, 0x00000fbd,
 	// Entry A0 - BF
-	0x00000f99, 0x00000fae, 0x00000fc7, 0x00000fd7,
-	0x00000fea, 0x00000ff6, 0x0000100b, 0x0000101e,
-	0x0000105e, 0x0000107d, 0x0000108a, 0x00001097,
-	0x000010ad, 0x000010ba, 0x000010c4, 0x000010d7,
-	0x000010e1, 0x000010f4, 0x0000112e, 0x00001156,
-	0x0000118f, 0x000011ab, 0x000011b2, 0x000011b9,
-	0x000011bd, 0x000011cb, 0x000011d2, 0x000011e5,
-	0x000011ec, 0x000011f6, 0x00001212, 0x00001222,
+	0x00000fcd, 0x00000fd4, 0x00000ffc, 0x00001006,
+	0x00001018, 0x0000102d, 0x00001046, 0x00001056,
+	0x00001069, 0x00001075, 0x0000108a, 0x0000109d,
+	0x000010dd, 0x000010fc, 0x00001109, 0x00001116,
+	0x0000112c, 0x00001139, 0x00001143, 0x00001156,
+	0x00001160, 0x00001173, 0x000011ad, 0x000011d5,
+	0x0000120e, 0x0000122a, 0x00001231, 0x00001238,
+	0x0000123c, 0x0000124a, 0x00001251, 0x00001264,
 	// Entry C0 - DF
-	0x00001232, 0x00001239, 0x00001240, 0x00001247,
-	0x0000124e, 0x00001267, 0x00001271, 0x0000127b,
-	0x00001288, 0x000012ac, 0x000012e6, 0x000012f0,
-	0x000012fd, 0x00001304, 0x0000130e, 0x0000131e,
-	0x0000132b, 0x00001347, 0x00001403, 0x0000142e,
-	0x0000144d, 0x00001454, 0x0000146d, 0x000014c5,
-	0x000014db, 0x000014eb, 0x0000157a, 0x00001593,
-	0x000015be, 0x000015e3, 0x000015ed, 0x0000161b,
+	0x0000126b, 0x00001275, 0x00001291, 0x000012a1,
+	0x000012b1, 0x000012b8, 0x000012bf, 0x000012c6,
+	0x000012cd, 0x000012e6, 0x000012f0, 0x000012fa,
+	0x00001307, 0x0000132b, 0x00001365, 0x0000136f,
+	0x0000137c, 0x00001383, 0x0000138d, 0x0000139d,
+	0x000013aa, 0x000013c6, 0x00001482, 0x000014ad,
+	0x000014cc, 0x000014d3, 0x000014ec, 0x00001544,
+	0x0000155a, 0x0000156a, 0x000015f9, 0x00001612,
 	// Entry E0 - FF
-	0x0000162b, 0x00001638, 0x0000164b, 0x0000166a,
-	0x00001688, 0x0000168f, 0x0000169f, 0x000016ac,
-	0x000016bc, 0x000016e1, 0x0000170b, 0x0000174b,
-	0x00001775, 0x000017b8, 0x000017bf, 0x000017db,
-	0x000017ef, 0x0000184e, 0x0000186a, 0x00001871,
-	0x000018a5, 0x000018b8, 0x000018d7, 0x00001932,
-	0x00001954, 0x0000199e, 0x000019ab, 0x000019ee,
-	0x00001a2f, 0x00001a6c, 0x00001a79, 0x00001ac5,
+	0x0000163d, 0x00001662, 0x0000166c, 0x0000169a,
+	0x000016aa, 0x000016b7, 0x000016ca, 0x000016e9,
+	0x00001707, 0x0000170e, 0x0000171e, 0x0000172b,
+	0x0000173b, 0x00001760, 0x000017bc, 0x000017e6,
+	0x00001826, 0x00001850, 0x00001893, 0x0000189a,
+	0x000018b6, 0x000018ca, 0x00001929, 0x00001945,
+	0x0000194c, 0x00001980, 0x00001993, 0x000019b2,
+	0x00001a0d, 0x00001a2f, 0x00001a79, 0x00001a86,
 	// Entry 100 - 11F
-	0x00001ade,
-} // Size: 1052 bytes
+	0x00001ac9, 0x00001b0a, 0x00001b47, 0x00001b54,
+	0x00001ba0, 0x00001bb9,
+} // Size: 1072 bytes
 
-const ja_JPData string = "" + // Size: 6878 bytes
+const ja_JPData string = "" + // Size: 7097 bytes
 	"\x02バージョン：%[1]s\x02FRP バージョン：%[1]s\x02コンパイル日：%[1]s\x02すべてのファイル\x02設定ファイル" +
 	"\x02証明書ファイル\x02秘密鍵ファイル\x02ログファイル\x02許容範囲外の数値\x02%[1]d より大きい数値を入力してください。" +
 	"\x02パスワードの不一致\x02もう一度確認してください。\x02数字ではありません\x02有効な数値を入力してください。\x02新しいバージ" +
@@ -718,43 +730,45 @@ const ja_JPData string = "" + // Size: 6878 bytes
 	"」は有効な ZIP ファイルではありません。\x02設定「%[1]s」を削除\x02設定「%[1]s」を削除してもよろしいですか?\x02新" +
 	"しいクライアント\x02クライアントの編集 - %[1]s\x02基本\x02名前\x02サーバーアドレス\x02サーバポート\x02ユーザ" +
 	"ー\x02STUNサーバー\x02認証\x02認証方法\x02なし\x02トークン\x02秘密鍵\x02受信者\x02範囲\x02トークンの" +
-	"URL\x02認証\x02接続を維持\x02作業接続\x02ログ\x02* ログを記録せず、元のログファイルを削除するには、空白のままにします。" +
-	"\x02ログファイル\x02ログファイルを選択\x02レベル\x02最大日数\x02管理者\x02管理者アドレス\x02管理ポート\x02パスワ" +
-	"ード\x02資産\x02管理サーバーがリソースをロードするローカルディレクトリを選択します。\x02自動削除\x02絶対\x02相対\x02" +
-	"削除日\x02日を削除\x02日\x02接続\x02プロトコル\x02HTTP プロキシ\x02接続プールの数\x02ハートビート\x02間" +
-	"隔\x02s\x02タイムアウト\x02接続タイムアウト\x02接続を維持\x02アイドルタイムアウト\x02最大ストリーム\x02有効" +
-	"\x02無効\x02ホスト名\x02証明書\x02証明書ファイルを選択\x02証明書キー\x02証明書キーファイルを選択します\x02信頼できる" +
-	" CA\x02信頼できる CA ファイルを選択します\x02高度\x02多重化\x02多重化接続を維持\x02送信元アドレス\x02別のオプショ" +
-	"ン\x02ログイン失敗後に終了\x02起動時に自動起動を無効にする\x02カスタム\x02実験的な機能\x02カスタムオプション\x02* " +
-	"FRP 設定ファイルの [common] セクションを参照してください。\x02* 以下の機能はサービスの安定性に影響を与える可能性があります。" +
-	"\x02サーバーSVCBレコードを使用する\x02設定はすでに存在します\x02設定名「%[1]s」はすでに存在します。\x02新しいプロキシ" +
-	"\x02プロキシの編集 - %[1]s\x02ランダム\x02タイプ\x02役割\x02サーバ\x02ビジター\x02秘密鍵\x02ローカルアド" +
-	"レス\x02ローカルポート\x02リモートポート\x02ユーザーを許可する\x02バインドアドレス\x02バインドポート\x02サーバー名" +
-	"\x02サーバーユーザー\x02サブドメイン\x02カスタムドメイン\x02URL ルーティング\x02マルチプレクサ\x02ルートユーザー" +
-	"\x02クライアント\x02帯域幅\x02プロキシプロトコル\x02自動\x02既定値\x02トンネルを維持する\x02暗号化\x02圧縮" +
-	"\x02リトライ回数\x02回/時間\x02再試行間隔\x02代替\x02フォールバックタイムアウト\x02ミリ秒\x02HTTP ユーザー" +
-	"\x02HTTP パスワード\x02ホストの書き換え\x02プラグイン\x02プラグイン名\x02Unix パス\x02Unix パスを選択" +
-	"\x02ローカルパス\x02ディレクトリリストのフォルダを選択します。\x02プレフィックスを削除\x02負荷平衡\x02グループ\x02グルー" +
-	"プ秘密鍵\x02健康診断\x02タイプ\x02タイムアウト\x02失敗数\x02チェック間隔\x02* FRP 対応のパラメータをご参照くだ" +
-	"さい。\x02プロキシはすでに存在します\x02プロキシ名「%[1]s」はすでに存在します。\x02ログフォルダを開く\x02最新\x02項" +
-	"目\x02値\x02NAT タイプ\x02挙動\x02外部アドレス\x02はい\x02いいえ\x02公共のネットワーク\x02わからない" +
-	"\x02ランニング\x02停止\x02起動\x02停止\x02状態\x02リモートアドレス\x02コピー\x02始める\x02サービス\x02設" +
-	"定「%[1]s」を停止します\x02設定「%[1]s」を停止してもよろしいですか?\x02止まる\x02フォルダ\x02追加\x02ポート" +
-	"\x02ポート開放\x02環境設定\x02マスターパスワード\x02パスワードを設定して、このプログラムへのアクセスを制限できます。\x0a次回" +
-	"このプログラムを使用するときに入力するよう求められます。\x02マスターパスワードを使用する\x02パスワードを変更する\x02言語\x02" +
-	"現在の表示言語は\x02変更を適用するには、プログラムを再起動する必要があります。\x02言語を選択する\x02デフォルト\x02新しい設定" +
-	"を作成するときのデフォルト値を定義します。\x0aここでの値は、既存の設定には影響しません。\x02デフォルトの設定\x02パスワードが解除" +
-	"されました。\x02新しいマスターパスワード\x02再入力\x02パスワードが設定されています。\x02ログレベル\x02ログ保持\x02ク" +
-	"イック追加\x02リモートデスクトップ\x02HTTP ファイルサーバー\x02有効\x02設定を開く\x02直接編集\x02ドメイン名" +
-	"\x02アクセスアドレスのコピー\x02プロキシ「%[1]s」を削除します\x02プロキシ「%[1]s」を削除してもよろしいですか?\x02プロ" +
-	"キシ「%[1]s」を無効にする\x02プロキシ「%[1]s」を無効にしてもよろしいですか?\x02無効\x02パッシブポート範囲\x02FR" +
-	"P マネージャ\x02* バッチインポートをサポートします、1行に1つのリンクがあります。\x02自動的に名前を変更\x02準備\x02正しいU" +
-	"RLリストを入力してください。\x02ダウンロード\x02パスワードを入力する\x02%[1]s を操作するには、管理パスワードを入力する必要が" +
-	"あります。\x02管理者パスワードを入力\x02パスワードが正しくありません。 パスワード再入力。\x02無効入力\x02%.[1]f から" +
-	" %.[2]f までの数字を入力してください。\x02%[1]s から %[2]s までの数値を入力してください。\x02テキストが必要なパター" +
-	"ンと一致しません。\x02選択必須\x02提供されたオプションのいずれかを選択してください。\x02選択が必要です。"
+	"URL\x02パラメーター\x02認証\x02接続を維持\x02作業接続\x02ログ\x02* ログを記録せず、元のログファイルを削除するには、" +
+	"空白のままにします。\x02ログファイル\x02ログファイルを選択\x02レベル\x02最大日数\x02管理者\x02管理者アドレス\x02" +
+	"パスワード\x02資産\x02管理サーバーがリソースをロードするローカルディレクトリを選択します。\x02別のオプション\x02自動削除" +
+	"\x02絶対\x02相対\x02削除日\x02日を削除\x02日\x02接続\x02プロトコル\x02HTTP プロキシ\x02接続プールの数" +
+	"\x02UDPパケットサイズ\x02ハートビート\x02間隔\x02s\x02タイムアウト\x02接続タイムアウト\x02接続を維持\x02アイ" +
+	"ドルタイムアウト\x02最大ストリーム\x02有効\x02無効\x02ホスト名\x02証明書\x02証明書ファイルを選択\x02証明書キー" +
+	"\x02証明書キーファイルを選択します\x02信頼できる CA\x02信頼できる CA ファイルを選択します\x02カスタムの先頭バイトを無効に" +
+	"する\x02高度\x02多重化\x02多重化接続を維持\x02送信元アドレス\x02ログイン失敗後に終了\x02起動時に自動起動を無効にする" +
+	"\x02メタデータ\x02実験的な機能\x02カスタムオプション\x02* FRP 設定ファイルの [common] セクションを参照してくださ" +
+	"い。\x02* 以下の機能はサービスの安定性に影響を与える可能性があります。\x02サーバーSVCBレコードを使用する\x02すべてクリア" +
+	"\x02設定はすでに存在します\x02設定名「%[1]s」はすでに存在します。\x02新しいプロキシ\x02プロキシの編集 - %[1]s" +
+	"\x02ランダム\x02タイプ\x02役割\x02サーバ\x02ビジター\x02秘密鍵\x02ローカルアドレス\x02ローカルポート\x02リモ" +
+	"ートポート\x02ユーザーを許可する\x02バインドアドレス\x02バインドポート\x02サーバー名\x02サーバーユーザー\x02サブドメ" +
+	"イン\x02カスタムドメイン\x02URL ルーティング\x02リクエストヘッダー\x02マルチプレクサ\x02ルートユーザー\x02クライ" +
+	"アント\x02帯域幅\x02プロキシプロトコル\x02自動\x02既定値\x02トンネルを維持する\x02暗号化\x02圧縮\x02リトライ" +
+	"回数\x02回/時間\x02再試行間隔\x02代替\x02フォールバックタイムアウト\x02ミリ秒\x02HTTP ユーザー\x02HTTP" +
+	" パスワード\x02ホストの書き換え\x02プラグイン\x02プラグイン名\x02Unix パス\x02Unix パスを選択\x02ローカルパス" +
+	"\x02ディレクトリリストのフォルダを選択します。\x02プレフィックスを削除\x02負荷平衡\x02グループ\x02グループ秘密鍵\x02健康" +
+	"診断\x02タイプ\x02タイムアウト\x02失敗数\x02チェック間隔\x02* FRP 対応のパラメータをご参照ください。\x02プロキ" +
+	"シはすでに存在します\x02プロキシ名「%[1]s」はすでに存在します。\x02ログフォルダを開く\x02最新\x02項目\x02値\x02" +
+	"NAT タイプ\x02挙動\x02外部アドレス\x02はい\x02いいえ\x02公共のネットワーク\x02わからない\x02ランニング\x02停" +
+	"止\x02起動\x02停止\x02状態\x02リモートアドレス\x02コピー\x02始める\x02サービス\x02設定「%[1]s」を停止し" +
+	"ます\x02設定「%[1]s」を停止してもよろしいですか?\x02止まる\x02フォルダ\x02追加\x02ポート\x02ポート開放\x02" +
+	"環境設定\x02マスターパスワード\x02パスワードを設定して、このプログラムへのアクセスを制限できます。\x0a次回このプログラムを使用す" +
+	"るときに入力するよう求められます。\x02マスターパスワードを使用する\x02パスワードを変更する\x02言語\x02現在の表示言語は" +
+	"\x02変更を適用するには、プログラムを再起動する必要があります。\x02言語を選択する\x02デフォルト\x02新しい設定を作成するときのデフ" +
+	"ォルト値を定義します。\x0aここでの値は、既存の設定には影響しません。\x02デフォルトの設定\x02パスワードが解除されました。\x02" +
+	"新しいマスターパスワード\x02再入力\x02パスワードが設定されています。\x02ログレベル\x02ログ保持\x02クイック追加\x02リ" +
+	"モートデスクトップ\x02HTTP ファイルサーバー\x02有効\x02設定を開く\x02直接編集\x02ドメイン名\x02アクセスアドレス" +
+	"のコピー\x02この機能は、INI または TOML 形式のテキストのみをサポートします。\x02プロキシ「%[1]s」を削除します\x02" +
+	"プロキシ「%[1]s」を削除してもよろしいですか?\x02プロキシ「%[1]s」を無効にする\x02プロキシ「%[1]s」を無効にしてもよろ" +
+	"しいですか?\x02無効\x02パッシブポート範囲\x02FRP マネージャ\x02* バッチインポートをサポートします、1行に1つのリンク" +
+	"があります。\x02自動的に名前を変更\x02準備\x02正しいURLリストを入力してください。\x02ダウンロード\x02パスワードを入力" +
+	"する\x02%[1]s を操作するには、管理パスワードを入力する必要があります。\x02管理者パスワードを入力\x02パスワードが正しくあり" +
+	"ません。 パスワード再入力。\x02無効入力\x02%.[1]f から %.[2]f までの数字を入力してください。\x02%[1]s から" +
+	" %[2]s までの数値を入力してください。\x02テキストが必要なパターンと一致しません。\x02選択必須\x02提供されたオプションのいずれ" +
+	"かを選択してください。\x02選択が必要です。"
 
-var ko_KRIndex = []uint32{ // 257 elements
+var ko_KRIndex = []uint32{ // 262 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000e, 0x00000020, 0x00000035,
 	0x00000043, 0x00000051, 0x00000062, 0x00000070,
@@ -775,63 +789,64 @@ var ko_KRIndex = []uint32{ // 257 elements
 	0x000005f2, 0x00000600, 0x00000607, 0x0000060e,
 	// Entry 40 - 5F
 	0x00000619, 0x00000627, 0x0000062e, 0x00000639,
-	0x00000640, 0x0000064b, 0x00000659, 0x00000663,
-	0x000006bd, 0x000006cb, 0x000006e0, 0x000006e7,
-	0x000006f5, 0x000006ff, 0x00000710, 0x0000071e,
-	0x0000072b, 0x00000732, 0x00000785, 0x00000793,
-	0x0000079a, 0x000007a4, 0x000007b2, 0x000007bd,
-	0x000007c1, 0x000007c8, 0x000007cf, 0x000007de,
-	0x000007e9, 0x000007f6, 0x000007fd, 0x000007ff,
+	0x00000646, 0x0000064d, 0x00000658, 0x00000666,
+	0x00000670, 0x000006ca, 0x000006d8, 0x000006ed,
+	0x000006f4, 0x00000702, 0x0000070c, 0x0000071d,
+	0x0000072a, 0x00000731, 0x00000784, 0x00000792,
+	0x000007a0, 0x000007a7, 0x000007b1, 0x000007bf,
+	0x000007ca, 0x000007ce, 0x000007d5, 0x000007dc,
+	0x000007eb, 0x000007f6, 0x00000808, 0x00000815,
 	// Entry 60 - 7F
-	0x0000080c, 0x00000821, 0x00000828, 0x0000083d,
-	0x0000084e, 0x00000855, 0x0000085c, 0x0000086d,
-	0x00000877, 0x0000088f, 0x0000089d, 0x000008b9,
-	0x000008d1, 0x000008f7, 0x00000901, 0x0000090b,
-	0x00000920, 0x0000092e, 0x0000093c, 0x00000958,
-	0x0000097e, 0x00000985, 0x00000996, 0x000009ae,
-	0x000009e9, 0x00000a39, 0x00000a53, 0x00000a72,
-	0x00000aa9, 0x00000ab7, 0x00000ad0, 0x00000add,
+	0x0000081c, 0x0000081e, 0x0000082b, 0x00000840,
+	0x00000847, 0x0000085c, 0x0000086d, 0x00000874,
+	0x0000087b, 0x0000088c, 0x00000896, 0x000008ae,
+	0x000008bc, 0x000008d8, 0x000008f0, 0x00000916,
+	0x0000093f, 0x00000949, 0x00000953, 0x00000968,
+	0x00000976, 0x00000992, 0x000009b8, 0x000009c8,
+	0x000009d9, 0x000009f1, 0x00000a2c, 0x00000a7c,
+	0x00000a96, 0x00000aa7, 0x00000ac6, 0x00000afd,
 	// Entry 80 - 9F
-	0x00000ae4, 0x00000aeb, 0x00000af2, 0x00000afc,
-	0x00000b07, 0x00000b15, 0x00000b23, 0x00000b31,
-	0x00000b42, 0x00000b53, 0x00000b64, 0x00000b72,
-	0x00000b83, 0x00000b94, 0x00000baf, 0x00000bbd,
-	0x00000bcd, 0x00000bde, 0x00000bee, 0x00000bf8,
-	0x00000c0f, 0x00000c16, 0x00000c20, 0x00000c2e,
-	0x00000c38, 0x00000c3f, 0x00000c50, 0x00000c5b,
-	0x00000c6c, 0x00000c73, 0x00000c88, 0x00000c92,
+	0x00000b0b, 0x00000b24, 0x00000b31, 0x00000b38,
+	0x00000b3f, 0x00000b46, 0x00000b50, 0x00000b5b,
+	0x00000b69, 0x00000b77, 0x00000b85, 0x00000b96,
+	0x00000ba7, 0x00000bb8, 0x00000bc6, 0x00000bd7,
+	0x00000be8, 0x00000c03, 0x00000c11, 0x00000c1f,
+	0x00000c2f, 0x00000c40, 0x00000c50, 0x00000c5a,
+	0x00000c71, 0x00000c78, 0x00000c82, 0x00000c90,
+	0x00000c9a, 0x00000ca1, 0x00000cb2, 0x00000cbd,
 	// Entry A0 - BF
-	0x00000ca1, 0x00000cb3, 0x00000cc7, 0x00000cd4,
-	0x00000ce8, 0x00000cf4, 0x00000d07, 0x00000d15,
-	0x00000d51, 0x00000d65, 0x00000d73, 0x00000d7a,
-	0x00000d8c, 0x00000d9a, 0x00000da1, 0x00000daf,
-	0x00000dbd, 0x00000dc4, 0x00000e02, 0x00000e24,
-	0x00000e5e, 0x00000e73, 0x00000e7a, 0x00000e81,
-	0x00000e85, 0x00000e90, 0x00000e97, 0x00000ea5,
-	0x00000ea9, 0x00000eb3, 0x00000ec7, 0x00000edb,
+	0x00000cce, 0x00000cd5, 0x00000cea, 0x00000cf4,
+	0x00000d03, 0x00000d15, 0x00000d29, 0x00000d36,
+	0x00000d4a, 0x00000d56, 0x00000d69, 0x00000d77,
+	0x00000db3, 0x00000dc7, 0x00000dd5, 0x00000ddc,
+	0x00000dee, 0x00000dfc, 0x00000e03, 0x00000e11,
+	0x00000e1f, 0x00000e26, 0x00000e64, 0x00000e86,
+	0x00000ec0, 0x00000ed5, 0x00000edc, 0x00000ee3,
+	0x00000ee7, 0x00000ef2, 0x00000ef9, 0x00000f07,
 	// Entry C0 - DF
-	0x00000ee5, 0x00000eef, 0x00000ef6, 0x00000efd,
-	0x00000f04, 0x00000f12, 0x00000f19, 0x00000f20,
-	0x00000f2a, 0x00000f40, 0x00000f6c, 0x00000f73,
-	0x00000f87, 0x00000f94, 0x00000f9b, 0x00000fa9,
-	0x00000fb0, 0x00000fc7, 0x00001083, 0x000010a1,
-	0x000010b5, 0x000010bc, 0x000010d4, 0x00001120,
-	0x0000112e, 0x00001138, 0x000011b0, 0x000011c7,
-	0x000011e8, 0x00001203, 0x0000121a, 0x00001245,
+	0x00000f0b, 0x00000f15, 0x00000f29, 0x00000f3d,
+	0x00000f47, 0x00000f51, 0x00000f58, 0x00000f5f,
+	0x00000f66, 0x00000f74, 0x00000f7b, 0x00000f82,
+	0x00000f8c, 0x00000fa2, 0x00000fce, 0x00000fd5,
+	0x00000fe9, 0x00000ff6, 0x00000ffd, 0x0000100b,
+	0x00001012, 0x00001029, 0x000010e5, 0x00001103,
+	0x00001117, 0x0000111e, 0x00001136, 0x00001182,
+	0x00001190, 0x0000119a, 0x00001212, 0x00001229,
 	// Entry E0 - FF
-	0x00001253, 0x00001261, 0x0000126f, 0x00001283,
-	0x00001296, 0x0000129d, 0x000012ab, 0x000012b9,
-	0x000012c3, 0x000012db, 0x000012f4, 0x00001323,
-	0x00001342, 0x00001377, 0x0000137e, 0x00001396,
-	0x000013a4, 0x000013ed, 0x0000140b, 0x00001419,
-	0x00001442, 0x0000144f, 0x00001460, 0x000014a7,
-	0x000014c2, 0x00001515, 0x00001526, 0x0000155e,
-	0x00001598, 0x000015d1, 0x000015df, 0x00001612,
+	0x0000124a, 0x00001265, 0x0000127c, 0x000012a7,
+	0x000012b5, 0x000012c3, 0x000012d1, 0x000012e5,
+	0x000012f8, 0x000012ff, 0x0000130d, 0x0000131b,
+	0x00001325, 0x0000133d, 0x00001383, 0x0000139c,
+	0x000013cb, 0x000013ea, 0x0000141f, 0x00001426,
+	0x0000143e, 0x0000144c, 0x00001495, 0x000014b3,
+	0x000014c1, 0x000014ea, 0x000014f7, 0x00001508,
+	0x0000154f, 0x0000156a, 0x000015bd, 0x000015ce,
 	// Entry 100 - 11F
-	0x0000162d,
-} // Size: 1052 bytes
+	0x00001606, 0x00001640, 0x00001679, 0x00001687,
+	0x000016ba, 0x000016d5,
+} // Size: 1072 bytes
 
-const ko_KRData string = "" + // Size: 5677 bytes
+const ko_KRData string = "" + // Size: 5845 bytes
 	"\x02버전: %[1]s\x02FRP 버전: %[1]s\x02빌드 날짜: %[1]s\x02모든 파일\x02구성 파일\x02인증서 " +
 	"파일\x02열쇠 파일\x02로그 파일\x02허용 범위를 벗어난 숫자\x02%[1]d보다 큰 숫자를 입력하세요.\x02암호 불일" +
 	"치\x02확인하고 다시 시도해 주세요.\x02숫자가 아님\x02유효한 숫자를 입력하세요.\x02새로운 버전!\x02에 대한" +
@@ -845,43 +860,45 @@ const ko_KRData string = "" + // Size: 5677 bytes
 	"인 다른 구성이 이미 있습니다.\x02\x22%[1]s\x22 파일은 유효한 ZIP 파일이 아닙니다.\x02\x22%[1]s" +
 	"\x22 구성 삭제\x02\x22%[1]s\x22 구성을 삭제하시겠습니까?\x02새 클라이언트\x02클라이언트 편집 - %[1]s" +
 	"\x02기초적인\x02이름\x02서버 주소\x02서버 포트\x02사용자\x02STUN 서버\x02인증\x02인증 방법\x02없음" +
-	"\x02토큰\x02비밀 키\x02받는 사람\x02범위\x02토큰 URL\x02입증\x02대기 중\x02작동 연결\x02통나무" +
-	"\x02* 로그를 기록하지 않고 원본 로그 파일을 삭제하려면 비워 둡니다.\x02로그 파일\x02로그 파일 선택\x02수준\x02" +
-	"최대 일수\x02관리자\x02관리자 주소\x02관리 포트\x02비밀번호\x02자산\x02관리 서버가 리소스를 로드할 로컬 디렉" +
-	"토리를 선택하십시오.\x02자동 삭제\x02절대\x02상대적\x02날짜 삭제\x02삭제 일\x02날\x02연결\x02규약" +
-	"\x02HTTP 프록시\x02연결 수\x02심장박동\x02간격\x02s\x02타임아웃\x02연결 시간 초과\x02유지\x02유휴 " +
-	"시간 초과\x02최대 스트림\x02켜다\x02폐쇄\x02호스트 이름\x02자격증\x02인증서 파일 선택\x02인증서 키\x02" +
-	"인증서 키 파일 선택\x02신뢰할 수 있는 CA\x02신뢰할 수 있는 CA 파일 선택\x02고급의\x02다중화\x02다중화 대" +
-	"기 중\x02소스 주소\x02다른 옵션\x02로그인 실패 후 종료\x02부팅 시 자동 시작 비활성화\x02관습\x02실험적 기" +
-	"능\x02사용자 지정 옵션\x02* FRP 설정 파일의 [common] 부분을 참고하세요.\x02* 다음 기능은 서비스의 안정" +
-	"성에 영향을 미칠 수 있습니다.\x02서버 SVCB 기록 사용\x02구성이 이미 있습니다.\x02구성 이름 \x22%[1]s" +
-	"\x22 이(가) 이미 존재합니다.\x02새 프록시\x02프록시 편집 - %[1]s\x02무작위의\x02유형\x02역할\x02서버" +
-	"\x02방문객\x02비밀 키\x02지역 주소\x02로컬 포트\x02원격 포트\x02사용자 허용\x02바인드 주소\x02바인드 포트" +
-	"\x02서버 이름\x02서버 사용자\x02하위 도메인\x02사용자 정의 도메인\x02URL 라우팅\x02멀티플렉서\x02경로 사용" +
-	"자\x02클라이언트\x02대역폭\x02프록시 프로토콜\x02자동\x02기본값\x02터널 유지\x02암호화\x02압축\x02재시" +
-	"도 횟수\x02회/시간\x02재시도 간격\x02폴백\x02대체 시간 초과\x02밀리초\x02HTTP 사용자\x02HTTP 비밀" +
-	"번호\x02호스트 재작성\x02플러그인\x02플러그인 이름\x02Unix 경로\x02선택 Unix 경로\x02로컬 경로\x02" +
-	"디렉토리 목록에 대한 폴더를 선택하십시오.\x02스트립 접두사\x02부하 분산\x02그룹\x02그룹 비밀 키\x02건강 체크" +
-	"\x02유형\x02시간 초과\x02실패 횟수\x02간격\x02* FRP 에서 지원하는 매개변수를 참조하십시오.\x02프록시가 이미" +
-	" 있습니다.\x02프록시 이름 \x22%[1]s\x22 이(가) 이미 존재합니다.\x02로그 폴더 열기\x02최신\x02안건" +
-	"\x02값\x02NAT 유형\x02행실\x02외부 주소\x02예\x02아니요\x02공용 네트워크\x02알려지지 않은\x02달리기" +
-	"\x02중지됨\x02시작\x02멎는\x02상태\x02원격 주소\x02복사\x02시작\x02서비스\x02\x22%[1]s\x22 구" +
-	"성 중지\x02\x22%[1]s\x22 구성을 중지하시겠습니까?\x02중지\x02로컬 디렉토리\x02추가하다\x02포트\x02" +
-	"오픈 포트\x02옵션\x02마스터 비밀번호\x02이 프로그램에 대한 액세스를 제한하기 위해 암호를 설정할 수 있습니다.\x0a" +
-	"다음에 이 프로그램을 사용할 때 입력하라는 메시지가 표시됩니다.\x02마스터 비밀번호 사용\x02비밀번호 변경\x02언어" +
-	"\x02현재 표시 언어는\x02수정 사항을 적용하려면 프로그램을 재시작해야 합니다.\x02언어 선택\x02기본값\x02새 구성을 " +
-	"만들 때 기본값을 정의합니다.\x0a여기의 값은 기존 구성에 영향을 주지 않습니다.\x02기본값으로 설정\x02암호가 제거되었" +
-	"습니다.\x02새 마스터 비밀번호\x02비밀번호 재입력\x02비밀번호가 설정되어 있습니다.\x02로그 수준\x02로그 보존" +
-	"\x02빠른 추가\x02원격 데스크탑\x02HTTP 파일 서버\x02켜다\x02구성 열기\x02직접 편집\x02도메인\x02액세스" +
-	" 주소 복사\x02프록시 \x22%[1]s\x22 삭제\x02\x22%[1]s\x22 프록시를 삭제하시겠습니까?\x02프록시 " +
-	"\x22%[1]s\x22 비활성화\x02\x22%[1]s\x22 프록시를 비활성화하시겠습니까?\x02폐쇄\x02패시브 포트 범위" +
-	"\x02FRP 관리자\x02* 한 줄에 하나의 링크로 일괄 가져오기를 지원합니다.\x02자동으로 이름 바꾸기\x02준비가 된" +
-	"\x02올바른 URL 목록을 입력하세요.\x02다운로드\x02암호를 입력\x02%[1]s을(를) 작동하려면 관리 암호를 입력해야 " +
-	"합니다.\x02관리 비밀번호 입력\x02비밀번호가 올바르지 않습니다. 비밀번호를 다시 입력하세요.\x02잘못된 입력\x02%." +
-	"[1]f에서 %.[2]f까지의 숫자를 입력하세요.\x02%[1]s에서 %[2]s 사이의 숫자를 입력하십시오.\x02텍스트가 필수 " +
-	"패턴과 일치하지 않습니다.\x02선택 필수\x02제공된 옵션 중 하나를 선택하십시오.\x02선택이 필요합니다."
+	"\x02토큰\x02비밀 키\x02받는 사람\x02범위\x02토큰 URL\x02매개변수\x02입증\x02대기 중\x02작동 연결" +
+	"\x02통나무\x02* 로그를 기록하지 않고 원본 로그 파일을 삭제하려면 비워 둡니다.\x02로그 파일\x02로그 파일 선택" +
+	"\x02수준\x02최대 일수\x02관리자\x02관리자 주소\x02비밀번호\x02자산\x02관리 서버가 리소스를 로드할 로컬 디렉토" +
+	"리를 선택하십시오.\x02다른 옵션\x02자동 삭제\x02절대\x02상대적\x02날짜 삭제\x02삭제 일\x02날\x02연결" +
+	"\x02규약\x02HTTP 프록시\x02연결 수\x02UDP 패킷 크기\x02심장박동\x02간격\x02s\x02타임아웃\x02연결" +
+	" 시간 초과\x02유지\x02유휴 시간 초과\x02최대 스트림\x02켜다\x02폐쇄\x02호스트 이름\x02자격증\x02인증서 파" +
+	"일 선택\x02인증서 키\x02인증서 키 파일 선택\x02신뢰할 수 있는 CA\x02신뢰할 수 있는 CA 파일 선택\x02맞춤" +
+	" 첫 번째 바이트 비활성화\x02고급의\x02다중화\x02다중화 대기 중\x02소스 주소\x02로그인 실패 후 종료\x02부팅 시" +
+	" 자동 시작 비활성화\x02메타데이터\x02실험적 기능\x02사용자 지정 옵션\x02* FRP 설정 파일의 [common] 부분을" +
+	" 참고하세요.\x02* 다음 기능은 서비스의 안정성에 영향을 미칠 수 있습니다.\x02서버 SVCB 기록 사용\x02모두 지우기" +
+	"\x02구성이 이미 있습니다.\x02구성 이름 \x22%[1]s\x22 이(가) 이미 존재합니다.\x02새 프록시\x02프록시 편" +
+	"집 - %[1]s\x02무작위의\x02유형\x02역할\x02서버\x02방문객\x02비밀 키\x02지역 주소\x02로컬 포트" +
+	"\x02원격 포트\x02사용자 허용\x02바인드 주소\x02바인드 포트\x02서버 이름\x02서버 사용자\x02하위 도메인\x02" +
+	"사용자 정의 도메인\x02URL 라우팅\x02요청 헤더\x02멀티플렉서\x02경로 사용자\x02클라이언트\x02대역폭\x02프" +
+	"록시 프로토콜\x02자동\x02기본값\x02터널 유지\x02암호화\x02압축\x02재시도 횟수\x02회/시간\x02재시도 간격" +
+	"\x02폴백\x02대체 시간 초과\x02밀리초\x02HTTP 사용자\x02HTTP 비밀번호\x02호스트 재작성\x02플러그인" +
+	"\x02플러그인 이름\x02Unix 경로\x02선택 Unix 경로\x02로컬 경로\x02디렉토리 목록에 대한 폴더를 선택하십시오." +
+	"\x02스트립 접두사\x02부하 분산\x02그룹\x02그룹 비밀 키\x02건강 체크\x02유형\x02시간 초과\x02실패 횟수" +
+	"\x02간격\x02* FRP 에서 지원하는 매개변수를 참조하십시오.\x02프록시가 이미 있습니다.\x02프록시 이름 \x22%[1" +
+	"]s\x22 이(가) 이미 존재합니다.\x02로그 폴더 열기\x02최신\x02안건\x02값\x02NAT 유형\x02행실\x02외부" +
+	" 주소\x02예\x02아니요\x02공용 네트워크\x02알려지지 않은\x02달리기\x02중지됨\x02시작\x02멎는\x02상태" +
+	"\x02원격 주소\x02복사\x02시작\x02서비스\x02\x22%[1]s\x22 구성 중지\x02\x22%[1]s\x22 구성을" +
+	" 중지하시겠습니까?\x02중지\x02로컬 디렉토리\x02추가하다\x02포트\x02오픈 포트\x02옵션\x02마스터 비밀번호\x02" +
+	"이 프로그램에 대한 액세스를 제한하기 위해 암호를 설정할 수 있습니다.\x0a다음에 이 프로그램을 사용할 때 입력하라는 메시지" +
+	"가 표시됩니다.\x02마스터 비밀번호 사용\x02비밀번호 변경\x02언어\x02현재 표시 언어는\x02수정 사항을 적용하려면 " +
+	"프로그램을 재시작해야 합니다.\x02언어 선택\x02기본값\x02새 구성을 만들 때 기본값을 정의합니다.\x0a여기의 값은 기" +
+	"존 구성에 영향을 주지 않습니다.\x02기본값으로 설정\x02암호가 제거되었습니다.\x02새 마스터 비밀번호\x02비밀번호 재" +
+	"입력\x02비밀번호가 설정되어 있습니다.\x02로그 수준\x02로그 보존\x02빠른 추가\x02원격 데스크탑\x02HTTP 파" +
+	"일 서버\x02켜다\x02구성 열기\x02직접 편집\x02도메인\x02액세스 주소 복사\x02이 기능은 INI 또는 TOML " +
+	"형식의 텍스트만 지원합니다.\x02프록시 \x22%[1]s\x22 삭제\x02\x22%[1]s\x22 프록시를 삭제하시겠습니까" +
+	"?\x02프록시 \x22%[1]s\x22 비활성화\x02\x22%[1]s\x22 프록시를 비활성화하시겠습니까?\x02폐쇄\x02패" +
+	"시브 포트 범위\x02FRP 관리자\x02* 한 줄에 하나의 링크로 일괄 가져오기를 지원합니다.\x02자동으로 이름 바꾸기" +
+	"\x02준비가 된\x02올바른 URL 목록을 입력하세요.\x02다운로드\x02암호를 입력\x02%[1]s을(를) 작동하려면 관리 " +
+	"암호를 입력해야 합니다.\x02관리 비밀번호 입력\x02비밀번호가 올바르지 않습니다. 비밀번호를 다시 입력하세요.\x02잘못된" +
+	" 입력\x02%.[1]f에서 %.[2]f까지의 숫자를 입력하세요.\x02%[1]s에서 %[2]s 사이의 숫자를 입력하십시오." +
+	"\x02텍스트가 필수 패턴과 일치하지 않습니다.\x02선택 필수\x02제공된 옵션 중 하나를 선택하십시오.\x02선택이 필요합니다" +
+	"."
 
-var zh_CNIndex = []uint32{ // 257 elements
+var zh_CNIndex = []uint32{ // 262 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000f, 0x00000022, 0x00000037,
 	0x00000044, 0x00000051, 0x0000005e, 0x0000006b,
@@ -902,63 +919,64 @@ var zh_CNIndex = []uint32{ // 257 elements
 	0x000004bf, 0x000004cc, 0x000004d0, 0x000004d7,
 	// Entry 40 - 5F
 	0x000004de, 0x000004e8, 0x000004f2, 0x000004ff,
-	0x00000506, 0x00000513, 0x00000520, 0x00000527,
-	0x00000566, 0x00000573, 0x00000586, 0x0000058d,
-	0x0000059a, 0x000005a1, 0x000005ae, 0x000005bb,
-	0x000005c2, 0x000005cf, 0x00000603, 0x00000610,
-	0x00000617, 0x0000061e, 0x0000062b, 0x00000638,
-	0x0000063c, 0x00000643, 0x0000064a, 0x00000656,
-	0x00000666, 0x0000066d, 0x00000674, 0x00000678,
+	0x00000506, 0x0000050d, 0x0000051a, 0x00000527,
+	0x0000052e, 0x0000056d, 0x0000057a, 0x0000058d,
+	0x00000594, 0x000005a1, 0x000005a8, 0x000005b5,
+	0x000005bc, 0x000005c9, 0x000005fd, 0x0000060a,
+	0x00000617, 0x0000061e, 0x00000625, 0x00000632,
+	0x0000063f, 0x00000643, 0x0000064a, 0x00000651,
+	0x0000065d, 0x0000066d, 0x0000067b, 0x00000682,
 	// Entry 60 - 7F
-	0x0000067f, 0x0000068c, 0x00000699, 0x000006a6,
-	0x000006b6, 0x000006bd, 0x000006c4, 0x000006d1,
-	0x000006de, 0x000006f1, 0x000006fe, 0x00000717,
-	0x00000727, 0x00000740, 0x00000747, 0x00000754,
-	0x00000764, 0x00000774, 0x00000781, 0x0000079d,
-	0x000007b3, 0x000007bd, 0x000007cd, 0x000007dd,
-	0x0000080d, 0x00000840, 0x0000085c, 0x0000086c,
-	0x0000088d, 0x0000089a, 0x000008af, 0x000008bc,
+	0x00000689, 0x0000068d, 0x00000694, 0x000006a1,
+	0x000006ae, 0x000006bb, 0x000006cb, 0x000006d2,
+	0x000006d9, 0x000006e6, 0x000006f3, 0x00000706,
+	0x00000713, 0x0000072c, 0x0000073c, 0x00000755,
+	0x0000076e, 0x00000775, 0x00000782, 0x00000792,
+	0x000007a2, 0x000007be, 0x000007d4, 0x000007de,
+	0x000007ee, 0x000007fe, 0x0000082e, 0x00000861,
+	0x0000087d, 0x0000088a, 0x0000089a, 0x000008bb,
 	// Entry 80 - 9F
-	0x000008c3, 0x000008ca, 0x000008d4, 0x000008de,
-	0x000008e5, 0x000008f2, 0x000008ff, 0x0000090c,
-	0x00000919, 0x00000926, 0x00000933, 0x00000940,
-	0x0000094d, 0x00000957, 0x00000967, 0x00000972,
-	0x0000097c, 0x00000989, 0x00000993, 0x000009a0,
-	0x000009ad, 0x000009b4, 0x000009bb, 0x000009c8,
-	0x000009d5, 0x000009e2, 0x000009ef, 0x000009fa,
-	0x00000a07, 0x00000a0e, 0x00000a1b, 0x00000a22,
+	0x000008c8, 0x000008dd, 0x000008ea, 0x000008f1,
+	0x000008f8, 0x00000902, 0x0000090c, 0x00000913,
+	0x00000920, 0x0000092d, 0x0000093a, 0x00000947,
+	0x00000954, 0x00000961, 0x0000096e, 0x0000097b,
+	0x00000985, 0x00000995, 0x000009a0, 0x000009aa,
+	0x000009b4, 0x000009c1, 0x000009cb, 0x000009d8,
+	0x000009e5, 0x000009ec, 0x000009f3, 0x00000a00,
+	0x00000a0d, 0x00000a1a, 0x00000a27, 0x00000a32,
 	// Entry A0 - BF
-	0x00000a2e, 0x00000a3a, 0x00000a46, 0x00000a4d,
-	0x00000a5a, 0x00000a66, 0x00000a79, 0x00000a86,
-	0x00000ab4, 0x00000ac1, 0x00000ace, 0x00000adb,
-	0x00000ae8, 0x00000af5, 0x00000b02, 0x00000b0f,
-	0x00000b1c, 0x00000b29, 0x00000b49, 0x00000b59,
-	0x00000b7a, 0x00000b90, 0x00000b97, 0x00000b9e,
-	0x00000ba2, 0x00000bad, 0x00000bb4, 0x00000bc1,
-	0x00000bc5, 0x00000bc9, 0x00000bd0, 0x00000bd7,
+	0x00000a3f, 0x00000a46, 0x00000a53, 0x00000a5a,
+	0x00000a66, 0x00000a72, 0x00000a7e, 0x00000a85,
+	0x00000a92, 0x00000a9e, 0x00000ab1, 0x00000abe,
+	0x00000aec, 0x00000af9, 0x00000b06, 0x00000b13,
+	0x00000b20, 0x00000b2d, 0x00000b3a, 0x00000b47,
+	0x00000b54, 0x00000b61, 0x00000b81, 0x00000b91,
+	0x00000bb2, 0x00000bc8, 0x00000bcf, 0x00000bd6,
+	0x00000bda, 0x00000be5, 0x00000bec, 0x00000bf9,
 	// Entry C0 - DF
-	0x00000be4, 0x00000bee, 0x00000bfb, 0x00000c08,
-	0x00000c0f, 0x00000c1c, 0x00000c23, 0x00000c2a,
-	0x00000c31, 0x00000c49, 0x00000c70, 0x00000c77,
-	0x00000c84, 0x00000c8b, 0x00000c92, 0x00000c9f,
-	0x00000ca6, 0x00000cb0, 0x00000d1e, 0x00000d2e,
-	0x00000d3b, 0x00000d42, 0x00000d58, 0x00000d89,
-	0x00000d96, 0x00000da0, 0x00000df0, 0x00000e00,
-	0x00000e13, 0x00000e20, 0x00000e2d, 0x00000e40,
+	0x00000bfd, 0x00000c01, 0x00000c08, 0x00000c0f,
+	0x00000c1c, 0x00000c26, 0x00000c33, 0x00000c40,
+	0x00000c47, 0x00000c54, 0x00000c5b, 0x00000c62,
+	0x00000c69, 0x00000c81, 0x00000ca8, 0x00000caf,
+	0x00000cbc, 0x00000cc3, 0x00000cca, 0x00000cd7,
+	0x00000cde, 0x00000ce8, 0x00000d56, 0x00000d66,
+	0x00000d73, 0x00000d7a, 0x00000d90, 0x00000dc1,
+	0x00000dce, 0x00000dd8, 0x00000e28, 0x00000e38,
 	// Entry E0 - FF
-	0x00000e4d, 0x00000e5a, 0x00000e67, 0x00000e74,
-	0x00000e86, 0x00000e8d, 0x00000ea0, 0x00000ead,
-	0x00000eb4, 0x00000ec7, 0x00000edf, 0x00000f06,
-	0x00000f1e, 0x00000f45, 0x00000f4c, 0x00000f5f,
-	0x00000f6d, 0x00000f9a, 0x00000faa, 0x00000fb7,
-	0x00000fd8, 0x00000fdf, 0x00000fec, 0x0000101a,
-	0x0000102d, 0x0000104f, 0x0000105c, 0x0000108e,
-	0x000010be, 0x000010e3, 0x000010ed, 0x0000110c,
+	0x00000e4b, 0x00000e58, 0x00000e65, 0x00000e78,
+	0x00000e85, 0x00000e92, 0x00000e9f, 0x00000eac,
+	0x00000ebe, 0x00000ec5, 0x00000ed8, 0x00000ee5,
+	0x00000eec, 0x00000eff, 0x00000f32, 0x00000f4a,
+	0x00000f71, 0x00000f89, 0x00000fb0, 0x00000fb7,
+	0x00000fca, 0x00000fd8, 0x00001005, 0x00001015,
+	0x00001022, 0x00001043, 0x0000104a, 0x00001057,
+	0x00001085, 0x00001098, 0x000010ba, 0x000010c7,
 	// Entry 100 - 11F
-	0x0000111c,
-} // Size: 1052 bytes
+	0x000010f9, 0x00001129, 0x0000114e, 0x00001158,
+	0x00001177, 0x00001187,
+} // Size: 1072 bytes
 
-const zh_CNData string = "" + // Size: 4380 bytes
+const zh_CNData string = "" + // Size: 4487 bytes
 	"\x02版本：%[1]s\x02FRP 版本：%[1]s\x02构建日期：%[1]s\x02所有文件\x02配置文件\x02证书文件\x02密钥" +
 	"文件\x02日志文件\x02数值超出允许范围\x02请输入一个大于 %[1]d 的数字。\x02密码不匹配\x02请检查并重试。\x02不是" +
 	"数字\x02请输入一个有效的数字。\x02发现更新！\x02关于\x02下载更新\x02正在检查更新\x02检查更新\x02如有任何意见或报" +
@@ -969,35 +987,36 @@ const zh_CNData string = "" + // Size: 4380 bytes
 	"手动设置\x02导入了 %[2]d 个配置文件中的 %[1]d 个。\x02另一个同名的配置「%[1]s」已存在。\x02文件 \x22%[" +
 	"1]s\x22 不是有效的压缩文件。\x02删除配置「%[1]s」\x02确定要删除配置「%[1]s」吗？此操作无法撤销。\x02新建客户端" +
 	"\x02编辑客户端 - %[1]s\x02基本\x02名称\x02服务器地址\x02服务器端口\x02用户名\x02STUN 服务\x02认证" +
-	"\x02认证方式\x02无\x02令牌\x02密钥\x02接收者\x02作用域\x02令牌地址\x02鉴权\x02心跳消息\x02工作连接" +
-	"\x02日志\x02* 留空则不记录日志，且删除原来的日志文件。\x02日志文件\x02选择日志文件\x02级别\x02最大天数\x02管理" +
-	"\x02管理地址\x02管理端口\x02密码\x02静态资源\x02选择管理服务器使用的静态资源目录。\x02自动删除\x02绝对\x02相对" +
-	"\x02删除日期\x02删除天数\x02天\x02连接\x02协议\x02HTTP 代理\x02连接池数量\x02心跳\x02间隔\x02秒" +
-	"\x02超时\x02连接超时\x02保活周期\x02闲置超时\x02最大流数量\x02开启\x02关闭\x02主机名称\x02证书文件\x02选" +
-	"择证书文件\x02密钥文件\x02选择证书密钥文件\x02受信任证书\x02选择受信任的证书\x02高级\x02多路复用\x02复用器心跳" +
-	"\x02使用源地址\x02其他选项\x02初次登录失败后退出\x02禁用开机自启动\x02自定义\x02实验性功能\x02自定义参数\x02* " +
-	"参考 FRP 配置文件的 [common] 部分。\x02* 以下功能可能会影响服务的稳定性。\x02使用服务器 SVCB 记录\x02配置" +
-	"已存在\x02配置名「%[1]s」已存在。\x02新建代理\x02编辑代理 - %[1]s\x02随机名称\x02类型\x02角色\x02服" +
-	"务端\x02访问者\x02私钥\x02本地地址\x02本地端口\x02远程端口\x02允许用户\x02绑定地址\x02绑定端口\x02服务名" +
-	"称\x02服务用户\x02子域名\x02自定义域名\x02URL 路由\x02复用器\x02路由用户\x02客户端\x02带宽限流\x02代" +
-	"理协议\x02自动\x02默认\x02隧道保活\x02加密传输\x02压缩传输\x02重试次数\x02次/小时\x02重试间隔\x02备用" +
-	"\x02备用超时\x02毫秒\x02HTTP 用户\x02HTTP 密码\x02Host 替换\x02插件\x02插件名称\x02Unix 路径" +
-	"\x02选择 Unix 路径\x02本地路径\x02选择需要显示目录列表的文件夹。\x02移除前缀\x02负载均衡\x02分组名称\x02分组密" +
-	"钥\x02健康检查\x02检查类型\x02检查超时\x02错误次数\x02检查周期\x02* 参考 FRP 支持的参数。\x02代理已存在" +
-	"\x02代理名「%[1]s」已存在。\x02打开日志文件夹\x02最新\x02项目\x02值\x02NAT 类型\x02行为\x02外部地址" +
-	"\x02是\x02否\x02公网\x02未知\x02正在运行\x02已停止\x02正在启动\x02正在停止\x02状态\x02远程地址\x02复" +
-	"制\x02启动\x02服务\x02停止配置「%[1]s」\x02确定要停止配置「%[1]s」吗？\x02停止\x02本地目录\x02添加" +
-	"\x02端口\x02打开端口\x02选项\x02主密码\x02您可以设置密码来限制访问此程序。\x0a在下次使用此程序时，您将被要求输入密码。" +
-	"\x02使用主密码\x02修改密码\x02语言\x02目前的显示语言\x02您必须重新启动程序才能应用修改。\x02选择语言\x02默认值" +
-	"\x02定义新建配置时的默认值。\x0a此处的值不会影响现有的配置。\x02设置默认值\x02密码已删除。\x02新主密码\x02确认密码" +
-	"\x02密码已设定。\x02日志级别\x02日志保留\x02快速添加\x02远程桌面\x02HTTP 文件服务\x02启用\x02打开配置文件" +
-	"\x02直接编辑\x02域名\x02复制访问地址\x02删除代理「%[1]s」\x02确定要删除代理「%[1]s」吗？\x02禁用代理「%[1]" +
-	"s」\x02确定要禁用代理「%[1]s」吗？\x02禁用\x02被动端口范围\x02FRP 管理器\x02* 支持批量导入，每行一个链接。" +
-	"\x02自动重命名\x02准备就绪\x02请输入正确的 URL 列表。\x02下载\x02输入密码\x02您必须输入管理密码来使用 %[1]s。" +
-	"\x02输入管理密码\x02密码错误。请重新输入。\x02输入无效\x02请输入一个从 %.[1]f 到 %.[2]f 的数字。\x02请输入一" +
-	"个从 %[1]s 到 %[2]s 的数字。\x02文本与要求的模式不匹配。\x02必填项\x02请选择其中一个选项。\x02需要选择。"
+	"\x02认证方式\x02无\x02令牌\x02密钥\x02接收者\x02作用域\x02令牌地址\x02参数\x02鉴权\x02心跳消息\x02工" +
+	"作连接\x02日志\x02* 留空则不记录日志，且删除原来的日志文件。\x02日志文件\x02选择日志文件\x02级别\x02最大天数" +
+	"\x02管理\x02管理地址\x02密码\x02静态资源\x02选择管理服务器使用的静态资源目录。\x02其他选项\x02自动删除\x02绝对" +
+	"\x02相对\x02删除日期\x02删除天数\x02天\x02连接\x02协议\x02HTTP 代理\x02连接池数量\x02UDP 包大小" +
+	"\x02心跳\x02间隔\x02秒\x02超时\x02连接超时\x02保活周期\x02闲置超时\x02最大流数量\x02开启\x02关闭\x02" +
+	"主机名称\x02证书文件\x02选择证书文件\x02密钥文件\x02选择证书密钥文件\x02受信任证书\x02选择受信任的证书\x02禁用自" +
+	"定义首字节\x02高级\x02多路复用\x02复用器心跳\x02使用源地址\x02初次登录失败后退出\x02禁用开机自启动\x02元数据" +
+	"\x02实验性功能\x02自定义参数\x02* 参考 FRP 配置文件的 [common] 部分。\x02* 以下功能可能会影响服务的稳定性。" +
+	"\x02使用服务器 SVCB 记录\x02全部清除\x02配置已存在\x02配置名「%[1]s」已存在。\x02新建代理\x02编辑代理 - %" +
+	"[1]s\x02随机名称\x02类型\x02角色\x02服务端\x02访问者\x02私钥\x02本地地址\x02本地端口\x02远程端口\x02" +
+	"允许用户\x02绑定地址\x02绑定端口\x02服务名称\x02服务用户\x02子域名\x02自定义域名\x02URL 路由\x02请求头" +
+	"\x02复用器\x02路由用户\x02客户端\x02带宽限流\x02代理协议\x02自动\x02默认\x02隧道保活\x02加密传输\x02压缩" +
+	"传输\x02重试次数\x02次/小时\x02重试间隔\x02备用\x02备用超时\x02毫秒\x02HTTP 用户\x02HTTP 密码" +
+	"\x02Host 替换\x02插件\x02插件名称\x02Unix 路径\x02选择 Unix 路径\x02本地路径\x02选择需要显示目录列表" +
+	"的文件夹。\x02移除前缀\x02负载均衡\x02分组名称\x02分组密钥\x02健康检查\x02检查类型\x02检查超时\x02错误次数" +
+	"\x02检查周期\x02* 参考 FRP 支持的参数。\x02代理已存在\x02代理名「%[1]s」已存在。\x02打开日志文件夹\x02最新" +
+	"\x02项目\x02值\x02NAT 类型\x02行为\x02外部地址\x02是\x02否\x02公网\x02未知\x02正在运行\x02已停止" +
+	"\x02正在启动\x02正在停止\x02状态\x02远程地址\x02复制\x02启动\x02服务\x02停止配置「%[1]s」\x02确定要停止" +
+	"配置「%[1]s」吗？\x02停止\x02本地目录\x02添加\x02端口\x02打开端口\x02选项\x02主密码\x02您可以设置密码来" +
+	"限制访问此程序。\x0a在下次使用此程序时，您将被要求输入密码。\x02使用主密码\x02修改密码\x02语言\x02目前的显示语言\x02" +
+	"您必须重新启动程序才能应用修改。\x02选择语言\x02默认值\x02定义新建配置时的默认值。\x0a此处的值不会影响现有的配置。\x02设" +
+	"置默认值\x02密码已删除。\x02新主密码\x02确认密码\x02密码已设定。\x02日志级别\x02日志保留\x02快速添加\x02远程" +
+	"桌面\x02HTTP 文件服务\x02启用\x02打开配置文件\x02直接编辑\x02域名\x02复制访问地址\x02此功能仅支持 INI " +
+	"或 TOML 格式的文本。\x02删除代理「%[1]s」\x02确定要删除代理「%[1]s」吗？\x02禁用代理「%[1]s」\x02确定要" +
+	"禁用代理「%[1]s」吗？\x02禁用\x02被动端口范围\x02FRP 管理器\x02* 支持批量导入，每行一个链接。\x02自动重命名" +
+	"\x02准备就绪\x02请输入正确的 URL 列表。\x02下载\x02输入密码\x02您必须输入管理密码来使用 %[1]s。\x02输入管理密" +
+	"码\x02密码错误。请重新输入。\x02输入无效\x02请输入一个从 %.[1]f 到 %.[2]f 的数字。\x02请输入一个从 %[1]" +
+	"s 到 %[2]s 的数字。\x02文本与要求的模式不匹配。\x02必填项\x02请选择其中一个选项。\x02需要选择。"
 
-var zh_TWIndex = []uint32{ // 257 elements
+var zh_TWIndex = []uint32{ // 262 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000f, 0x00000022, 0x00000037,
 	0x00000044, 0x00000051, 0x0000005e, 0x0000006b,
@@ -1018,63 +1037,64 @@ var zh_TWIndex = []uint32{ // 257 elements
 	0x000004bf, 0x000004cc, 0x000004d0, 0x000004d7,
 	// Entry 40 - 5F
 	0x000004de, 0x000004e8, 0x000004f2, 0x000004ff,
-	0x00000506, 0x00000513, 0x00000520, 0x00000527,
-	0x00000566, 0x00000573, 0x00000586, 0x0000058d,
-	0x0000059a, 0x000005a1, 0x000005ae, 0x000005bb,
-	0x000005c2, 0x000005cf, 0x00000603, 0x00000610,
-	0x00000617, 0x0000061e, 0x0000062b, 0x00000638,
-	0x0000063c, 0x00000643, 0x0000064a, 0x00000656,
-	0x00000666, 0x0000066d, 0x00000674, 0x00000678,
+	0x00000506, 0x0000050d, 0x0000051a, 0x00000527,
+	0x0000052e, 0x0000056d, 0x0000057a, 0x0000058d,
+	0x00000594, 0x000005a1, 0x000005a8, 0x000005b5,
+	0x000005bc, 0x000005c9, 0x000005fd, 0x0000060a,
+	0x00000617, 0x0000061e, 0x00000625, 0x00000632,
+	0x0000063f, 0x00000643, 0x0000064a, 0x00000651,
+	0x0000065d, 0x0000066d, 0x0000067b, 0x00000682,
 	// Entry 60 - 7F
-	0x0000067f, 0x0000068c, 0x00000699, 0x000006a6,
-	0x000006b6, 0x000006bd, 0x000006c4, 0x000006d1,
-	0x000006de, 0x000006f1, 0x000006fe, 0x00000717,
-	0x00000727, 0x00000740, 0x00000747, 0x00000754,
-	0x00000764, 0x00000774, 0x00000781, 0x0000079d,
-	0x000007b3, 0x000007bd, 0x000007cd, 0x000007dd,
-	0x0000080d, 0x00000840, 0x0000085c, 0x0000086c,
-	0x0000088d, 0x0000089a, 0x000008af, 0x000008bc,
+	0x00000689, 0x0000068d, 0x00000694, 0x000006a1,
+	0x000006ae, 0x000006bb, 0x000006cb, 0x000006d2,
+	0x000006d9, 0x000006e6, 0x000006f3, 0x00000706,
+	0x00000713, 0x0000072c, 0x0000073c, 0x00000755,
+	0x0000076b, 0x00000772, 0x0000077f, 0x0000078f,
+	0x0000079f, 0x000007bb, 0x000007d1, 0x000007db,
+	0x000007eb, 0x000007fb, 0x0000082b, 0x0000085e,
+	0x0000087a, 0x00000887, 0x00000897, 0x000008b8,
 	// Entry 80 - 9F
-	0x000008c3, 0x000008ca, 0x000008d4, 0x000008de,
-	0x000008e5, 0x000008f2, 0x000008ff, 0x0000090c,
-	0x00000919, 0x00000926, 0x00000933, 0x00000940,
-	0x0000094d, 0x00000957, 0x00000967, 0x00000972,
-	0x0000097c, 0x00000989, 0x00000993, 0x000009a0,
-	0x000009ad, 0x000009b4, 0x000009bb, 0x000009c8,
-	0x000009d5, 0x000009e2, 0x000009ef, 0x000009fa,
-	0x00000a07, 0x00000a0e, 0x00000a1b, 0x00000a22,
+	0x000008c5, 0x000008da, 0x000008e7, 0x000008ee,
+	0x000008f5, 0x000008ff, 0x00000909, 0x00000910,
+	0x0000091d, 0x0000092a, 0x00000937, 0x00000944,
+	0x00000951, 0x0000095e, 0x0000096b, 0x00000978,
+	0x00000982, 0x00000992, 0x0000099d, 0x000009a7,
+	0x000009b1, 0x000009be, 0x000009c8, 0x000009d5,
+	0x000009e2, 0x000009e9, 0x000009f0, 0x000009fd,
+	0x00000a0a, 0x00000a17, 0x00000a24, 0x00000a2f,
 	// Entry A0 - BF
-	0x00000a2e, 0x00000a3a, 0x00000a46, 0x00000a4d,
-	0x00000a5a, 0x00000a66, 0x00000a79, 0x00000a86,
-	0x00000ab4, 0x00000ac1, 0x00000ace, 0x00000adb,
-	0x00000ae8, 0x00000af5, 0x00000b02, 0x00000b0f,
-	0x00000b1c, 0x00000b29, 0x00000b49, 0x00000b59,
-	0x00000b7a, 0x00000b90, 0x00000b97, 0x00000b9e,
-	0x00000ba2, 0x00000bad, 0x00000bb4, 0x00000bc1,
-	0x00000bc5, 0x00000bc9, 0x00000bd0, 0x00000bd7,
+	0x00000a3c, 0x00000a43, 0x00000a50, 0x00000a57,
+	0x00000a63, 0x00000a6f, 0x00000a7b, 0x00000a82,
+	0x00000a8f, 0x00000a9b, 0x00000aae, 0x00000abb,
+	0x00000ae9, 0x00000af6, 0x00000b03, 0x00000b10,
+	0x00000b1d, 0x00000b2a, 0x00000b37, 0x00000b44,
+	0x00000b51, 0x00000b5e, 0x00000b7e, 0x00000b8e,
+	0x00000baf, 0x00000bc5, 0x00000bcc, 0x00000bd3,
+	0x00000bd7, 0x00000be2, 0x00000be9, 0x00000bf6,
 	// Entry C0 - DF
-	0x00000be4, 0x00000bee, 0x00000bfb, 0x00000c08,
-	0x00000c0f, 0x00000c1c, 0x00000c23, 0x00000c2a,
-	0x00000c31, 0x00000c49, 0x00000c70, 0x00000c77,
-	0x00000c84, 0x00000c8b, 0x00000c92, 0x00000c9f,
-	0x00000ca6, 0x00000cb0, 0x00000d1e, 0x00000d2e,
-	0x00000d3b, 0x00000d42, 0x00000d58, 0x00000d89,
-	0x00000d96, 0x00000da0, 0x00000df0, 0x00000e00,
-	0x00000e13, 0x00000e20, 0x00000e2d, 0x00000e40,
+	0x00000bfa, 0x00000bfe, 0x00000c05, 0x00000c0c,
+	0x00000c19, 0x00000c23, 0x00000c30, 0x00000c3d,
+	0x00000c44, 0x00000c51, 0x00000c58, 0x00000c5f,
+	0x00000c66, 0x00000c7e, 0x00000ca5, 0x00000cac,
+	0x00000cb9, 0x00000cc0, 0x00000cc7, 0x00000cd4,
+	0x00000cdb, 0x00000ce5, 0x00000d53, 0x00000d63,
+	0x00000d70, 0x00000d77, 0x00000d8d, 0x00000dbe,
+	0x00000dcb, 0x00000dd5, 0x00000e25, 0x00000e35,
 	// Entry E0 - FF
-	0x00000e4d, 0x00000e5a, 0x00000e67, 0x00000e74,
-	0x00000e86, 0x00000e8d, 0x00000ea0, 0x00000ead,
-	0x00000eb4, 0x00000ec7, 0x00000edf, 0x00000f06,
-	0x00000f1e, 0x00000f45, 0x00000f4c, 0x00000f5f,
-	0x00000f6d, 0x00000f9a, 0x00000faa, 0x00000fb7,
-	0x00000fd8, 0x00000fdf, 0x00000fec, 0x0000101a,
-	0x0000102d, 0x0000104f, 0x0000105c, 0x0000108e,
-	0x000010be, 0x000010e3, 0x000010ed, 0x0000110c,
+	0x00000e48, 0x00000e55, 0x00000e62, 0x00000e75,
+	0x00000e82, 0x00000e8f, 0x00000e9c, 0x00000ea9,
+	0x00000ebb, 0x00000ec2, 0x00000ed5, 0x00000ee2,
+	0x00000ee9, 0x00000efc, 0x00000f2f, 0x00000f47,
+	0x00000f6e, 0x00000f86, 0x00000fad, 0x00000fb4,
+	0x00000fc7, 0x00000fd5, 0x00001002, 0x00001012,
+	0x0000101f, 0x00001040, 0x00001047, 0x00001054,
+	0x00001082, 0x00001095, 0x000010b7, 0x000010c4,
 	// Entry 100 - 11F
-	0x0000111c,
-} // Size: 1052 bytes
+	0x000010f6, 0x00001126, 0x0000114b, 0x00001155,
+	0x00001174, 0x00001184,
+} // Size: 1072 bytes
 
-const zh_TWData string = "" + // Size: 4380 bytes
+const zh_TWData string = "" + // Size: 4484 bytes
 	"\x02版本：%[1]s\x02FRP 版本：%[1]s\x02構建日期：%[1]s\x02所有文件\x02配置文件\x02證書文件\x02密鑰" +
 	"文件\x02日誌文件\x02數值超出允許範圍\x02請輸入一個大於 %[1]d 的數字。\x02密碼不匹配\x02請檢查並重試。\x02不是" +
 	"數字\x02請輸入一個有效的數字。\x02發現更新！\x02關於\x02下載更新\x02正在檢查更新\x02檢查更新\x02如有任何意見或報" +
@@ -1085,32 +1105,33 @@ const zh_TWData string = "" + // Size: 4380 bytes
 	"手動設置\x02導入了 %[2]d 個配置文件中的 %[1]d 個。\x02另一個同名的配置「%[1]s」已存在。\x02文件 \x22%[" +
 	"1]s\x22 不是有效的壓縮文件。\x02刪除配置「%[1]s」\x02確定要刪除配置「%[1]s」嗎？此操作無法撤銷。\x02新建客戶端" +
 	"\x02編輯客戶端 - %[1]s\x02基本\x02名稱\x02服務器地址\x02服務器端口\x02用戶名\x02STUN 服務\x02認證" +
-	"\x02認證方式\x02無\x02令牌\x02密鑰\x02接收者\x02作用域\x02令牌地址\x02鑑權\x02心跳消息\x02工作連接" +
-	"\x02日誌\x02* 留空則不記錄日誌，且刪除原來的日誌文件。\x02日誌文件\x02選擇日誌文件\x02級別\x02最大天數\x02管理" +
-	"\x02管理地址\x02管理端口\x02密碼\x02靜態資源\x02選擇管理服務器使用的靜態資源目錄。\x02自動刪除\x02絕對\x02相對" +
-	"\x02刪除日期\x02刪除天數\x02天\x02連接\x02協議\x02HTTP 代理\x02連接池數量\x02心跳\x02間隔\x02秒" +
-	"\x02超時\x02連接超時\x02保活週期\x02閒置超時\x02最大流數量\x02開啟\x02關閉\x02主機名稱\x02證書文件\x02選" +
-	"擇證書文件\x02密鑰文件\x02選擇證書密鑰文件\x02受信任證書\x02選擇受信任的證書\x02高級\x02多路復用\x02復用器心跳" +
-	"\x02使用源地址\x02其他選項\x02初次登錄失敗後退出\x02禁用開機自啟動\x02自定義\x02實驗性功能\x02自定義參數\x02* " +
-	"參考 FRP 配置文件的 [common] 部分。\x02* 以下功能可能會影響服務的穩定性。\x02使用服務器 SVCB 記錄\x02配置" +
-	"已存在\x02配置名「%[1]s」已存在。\x02新建代理\x02編輯代理 - %[1]s\x02隨機名稱\x02類型\x02角色\x02服" +
-	"務端\x02訪問者\x02私鑰\x02本地地址\x02本地端口\x02遠程端口\x02允許用戶\x02綁定地址\x02綁定端口\x02服務名" +
-	"稱\x02服務用戶\x02子域名\x02自定義域名\x02URL 路由\x02復用器\x02路由用戶\x02客戶端\x02帶寬限流\x02代" +
-	"理協議\x02自動\x02默認\x02隧道保活\x02加密傳輸\x02壓縮傳輸\x02重試次數\x02次/小時\x02重試間隔\x02備用" +
-	"\x02備用超時\x02毫秒\x02HTTP 用戶\x02HTTP 密碼\x02Host 替換\x02插件\x02插件名稱\x02Unix 路徑" +
-	"\x02選擇 Unix 路徑\x02本地路徑\x02選擇需要顯示目錄列表的文件夾。\x02移除前綴\x02負載均衡\x02分組名稱\x02分組密" +
-	"鑰\x02健康檢查\x02檢查類型\x02檢查超時\x02錯誤次數\x02檢查週期\x02* 參考 FRP 支持的參數。\x02代理已存在" +
-	"\x02代理名「%[1]s」已存在。\x02打開日誌文件夾\x02最新\x02項目\x02值\x02NAT 類型\x02行為\x02外部地址" +
-	"\x02是\x02否\x02公網\x02未知\x02正在運行\x02已停止\x02正在啟動\x02正在停止\x02狀態\x02遠程地址\x02複" +
-	"製\x02啟動\x02服務\x02停止配置「%[1]s」\x02確定要停止配置「%[1]s」嗎？\x02停止\x02本地目錄\x02添加" +
-	"\x02端口\x02打開端口\x02選項\x02主密碼\x02您可以設置密碼來限制訪問此程式。\x0a在下次使用此程式時，您將被要求輸入密碼。" +
-	"\x02使用主密碼\x02修改密碼\x02語言\x02目前的顯示語言\x02您必須重新啟動程式才能應用修改。\x02選擇語言\x02默認值" +
-	"\x02定義新建配置時的默認值。\x0a此處的值不會影響現有的配置。\x02設置默認值\x02密碼已刪除。\x02新主密碼\x02確認密碼" +
-	"\x02密碼已設定。\x02日誌級別\x02日誌保留\x02快速添加\x02遠程桌面\x02HTTP 文件服務\x02啟用\x02打開配置文件" +
-	"\x02直接編輯\x02域名\x02複製訪問地址\x02刪除代理「%[1]s」\x02確定要刪除代理「%[1]s」嗎？\x02禁用代理「%[1]" +
-	"s」\x02確定要禁用代理「%[1]s」嗎？\x02禁用\x02被動端口範圍\x02FRP 管理器\x02* 支持批量導入，每行一個鏈接。" +
-	"\x02自動重命名\x02準備就緒\x02請輸入正確的 URL 列表。\x02下載\x02輸入密碼\x02您必須輸入管理密碼來使用 %[1]s。" +
-	"\x02輸入管理密碼\x02密碼錯誤。請重新輸入。\x02輸入無效\x02請輸入一個從 %.[1]f 到 %.[2]f 的數字。\x02請輸入一" +
-	"個從 %[1]s 到 %[2]s 的數字。\x02文本與要求的模式不匹配。\x02必填項\x02請選擇其中一個選項。\x02需要選擇。"
+	"\x02認證方式\x02無\x02令牌\x02密鑰\x02接收者\x02作用域\x02令牌地址\x02參數\x02鑑權\x02心跳消息\x02工" +
+	"作連接\x02日誌\x02* 留空則不記錄日誌，且刪除原來的日誌文件。\x02日誌文件\x02選擇日誌文件\x02級別\x02最大天數" +
+	"\x02管理\x02管理地址\x02密碼\x02靜態資源\x02選擇管理服務器使用的靜態資源目錄。\x02其他選項\x02自動刪除\x02絕對" +
+	"\x02相對\x02刪除日期\x02刪除天數\x02天\x02連接\x02協議\x02HTTP 代理\x02連接池數量\x02UDP 包大小" +
+	"\x02心跳\x02間隔\x02秒\x02超時\x02連接超時\x02保活週期\x02閒置超時\x02最大流數量\x02開啟\x02關閉\x02" +
+	"主機名稱\x02證書文件\x02選擇證書文件\x02密鑰文件\x02選擇證書密鑰文件\x02受信任證書\x02選擇受信任的證書\x02停用自" +
+	"訂首字節\x02高級\x02多路復用\x02復用器心跳\x02使用源地址\x02初次登錄失敗後退出\x02禁用開機自啟動\x02元數據" +
+	"\x02實驗性功能\x02自定義參數\x02* 參考 FRP 配置文件的 [common] 部分。\x02* 以下功能可能會影響服務的穩定性。" +
+	"\x02使用服務器 SVCB 記錄\x02全部清除\x02配置已存在\x02配置名「%[1]s」已存在。\x02新建代理\x02編輯代理 - %" +
+	"[1]s\x02隨機名稱\x02類型\x02角色\x02服務端\x02訪問者\x02私鑰\x02本地地址\x02本地端口\x02遠程端口\x02" +
+	"允許用戶\x02綁定地址\x02綁定端口\x02服務名稱\x02服務用戶\x02子域名\x02自定義域名\x02URL 路由\x02請求頭" +
+	"\x02復用器\x02路由用戶\x02客戶端\x02帶寬限流\x02代理協議\x02自動\x02默認\x02隧道保活\x02加密傳輸\x02壓縮" +
+	"傳輸\x02重試次數\x02次/小時\x02重試間隔\x02備用\x02備用超時\x02毫秒\x02HTTP 用戶\x02HTTP 密碼" +
+	"\x02Host 替換\x02插件\x02插件名稱\x02Unix 路徑\x02選擇 Unix 路徑\x02本地路徑\x02選擇需要顯示目錄列表" +
+	"的文件夾。\x02移除前綴\x02負載均衡\x02分組名稱\x02分組密鑰\x02健康檢查\x02檢查類型\x02檢查超時\x02錯誤次數" +
+	"\x02檢查週期\x02* 參考 FRP 支持的參數。\x02代理已存在\x02代理名「%[1]s」已存在。\x02打開日誌文件夾\x02最新" +
+	"\x02項目\x02值\x02NAT 類型\x02行為\x02外部地址\x02是\x02否\x02公網\x02未知\x02正在運行\x02已停止" +
+	"\x02正在啟動\x02正在停止\x02狀態\x02遠程地址\x02複製\x02啟動\x02服務\x02停止配置「%[1]s」\x02確定要停止" +
+	"配置「%[1]s」嗎？\x02停止\x02本地目錄\x02添加\x02端口\x02打開端口\x02選項\x02主密碼\x02您可以設置密碼來" +
+	"限制訪問此程式。\x0a在下次使用此程式時，您將被要求輸入密碼。\x02使用主密碼\x02修改密碼\x02語言\x02目前的顯示語言\x02" +
+	"您必須重新啟動程式才能應用修改。\x02選擇語言\x02默認值\x02定義新建配置時的默認值。\x0a此處的值不會影響現有的配置。\x02設" +
+	"置默認值\x02密碼已刪除。\x02新主密碼\x02確認密碼\x02密碼已設定。\x02日誌級別\x02日誌保留\x02快速添加\x02遠程" +
+	"桌面\x02HTTP 文件服務\x02啟用\x02打開配置文件\x02直接編輯\x02域名\x02複製訪問地址\x02此功能僅支援 INI " +
+	"或 TOML 格式的文字。\x02刪除代理「%[1]s」\x02確定要刪除代理「%[1]s」嗎？\x02禁用代理「%[1]s」\x02確定要" +
+	"禁用代理「%[1]s」嗎？\x02禁用\x02被動端口範圍\x02FRP 管理器\x02* 支持批量導入，每行一個鏈接。\x02自動重命名" +
+	"\x02準備就緒\x02請輸入正確的 URL 列表。\x02下載\x02輸入密碼\x02您必須輸入管理密碼來使用 %[1]s。\x02輸入管理密" +
+	"碼\x02密碼錯誤。請重新輸入。\x02輸入無效\x02請輸入一個從 %.[1]f 到 %.[2]f 的數字。\x02請輸入一個從 %[1]" +
+	"s 到 %[2]s 的數字。\x02文本與要求的模式不匹配。\x02必填項\x02請選擇其中一個選項。\x02需要選擇。"
 
-	// Total table size 37942 bytes (37KiB); checksum: 8AC307E7
+	// Total table size 38943 bytes (38KiB); checksum: 8FBD3046

--- a/i18n/locales/en-US/messages.gotext.json
+++ b/i18n/locales/en-US/messages.gotext.json
@@ -589,6 +589,13 @@
             "fuzzy": true
         },
         {
+            "id": "Parameters",
+            "message": "Parameters",
+            "translation": "Parameters",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "Authentication",
             "message": "Authentication",
             "translation": "Authentication",
@@ -666,13 +673,6 @@
             "fuzzy": true
         },
         {
-            "id": "Admin Port",
-            "message": "Admin Port",
-            "translation": "Admin Port",
-            "translatorComment": "Copied from source.",
-            "fuzzy": true
-        },
-        {
             "id": "Password",
             "message": "Password",
             "translation": "Password",
@@ -690,6 +690,13 @@
             "id": "Select a local directory that the admin server will load resources from.",
             "message": "Select a local directory that the admin server will load resources from.",
             "translation": "Select a local directory that the admin server will load resources from.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Other Options",
+            "message": "Other Options",
+            "translation": "Other Options",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -760,6 +767,13 @@
             "id": "Pool Count",
             "message": "Pool Count",
             "translation": "Pool Count",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "UDP Packet Size",
+            "message": "UDP Packet Size",
+            "translation": "UDP Packet Size",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -883,6 +897,13 @@
             "fuzzy": true
         },
         {
+            "id": "Disable custom first byte",
+            "message": "Disable custom first byte",
+            "translation": "Disable custom first byte",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "Advanced",
             "message": "Advanced",
             "translation": "Advanced",
@@ -911,13 +932,6 @@
             "fuzzy": true
         },
         {
-            "id": "Other Options",
-            "message": "Other Options",
-            "translation": "Other Options",
-            "translatorComment": "Copied from source.",
-            "fuzzy": true
-        },
-        {
             "id": "Exit after login failure",
             "message": "Exit after login failure",
             "translation": "Exit after login failure",
@@ -932,9 +946,9 @@
             "fuzzy": true
         },
         {
-            "id": "Custom",
-            "message": "Custom",
-            "translation": "Custom",
+            "id": "Metadata",
+            "message": "Metadata",
+            "translation": "Metadata",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -970,6 +984,13 @@
             "id": "Use server SVCB records",
             "message": "Use server SVCB records",
             "translation": "Use server SVCB records",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Clear All",
+            "message": "Clear All",
+            "translation": "Clear All",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -1137,6 +1158,13 @@
             "id": "Locations",
             "message": "Locations",
             "translation": "Locations",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Request headers",
+            "message": "Request headers",
+            "translation": "Request headers",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -1797,6 +1825,13 @@
             "id": "Copy Access Address",
             "message": "Copy Access Address",
             "translation": "Copy Access Address",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "This feature only supports text in INI or TOML format.",
+            "message": "This feature only supports text in INI or TOML format.",
+            "translation": "This feature only supports text in INI or TOML format.",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },

--- a/i18n/locales/es-ES/messages.gotext.json
+++ b/i18n/locales/es-ES/messages.gotext.json
@@ -455,6 +455,11 @@
             "translation": "Dirección de token"
         },
         {
+            "id": "Parameters",
+            "message": "Parameters",
+            "translation": "Parámetros"
+        },
+        {
             "id": "Authentication",
             "message": "Authentication",
             "translation": "Autenticación"
@@ -510,11 +515,6 @@
             "translation": "Dirección"
         },
         {
-            "id": "Admin Port",
-            "message": "Admin Port",
-            "translation": "Puerto"
-        },
-        {
             "id": "Password",
             "message": "Password",
             "translation": "Clave"
@@ -528,6 +528,11 @@
             "id": "Select a local directory that the admin server will load resources from.",
             "message": "Select a local directory that the admin server will load resources from.",
             "translation": "Seleccione un directorio local desde el que el servidor de administración cargará los recursos."
+        },
+        {
+            "id": "Other Options",
+            "message": "Other Options",
+            "translation": "Otras opciones"
         },
         {
             "id": "Auto Delete",
@@ -578,6 +583,11 @@
             "id": "Pool Count",
             "message": "Pool Count",
             "translation": "Conectar cuenta"
+        },
+        {
+            "id": "UDP Packet Size",
+            "message": "UDP Packet Size",
+            "translation": "Tamaño del paquete UDP"
         },
         {
             "id": "Heartbeat",
@@ -665,6 +675,11 @@
             "translation": "Seleccionar archivo CA de confianza"
         },
         {
+            "id": "Disable custom first byte",
+            "message": "Disable custom first byte",
+            "translation": "Desactivar primer byte personalizado"
+        },
+        {
             "id": "Advanced",
             "message": "Advanced",
             "translation": "Avanzado"
@@ -685,11 +700,6 @@
             "translation": "Dirección de la fuente"
         },
         {
-            "id": "Other Options",
-            "message": "Other Options",
-            "translation": "Otras opciones"
-        },
-        {
             "id": "Exit after login failure",
             "message": "Exit after login failure",
             "translation": "Salir después de fallar el inicio de sesión"
@@ -700,9 +710,9 @@
             "translation": "Desactivar el inicio automático al arrancar"
         },
         {
-            "id": "Custom",
-            "message": "Custom",
-            "translation": "Disfraz"
+            "id": "Metadata",
+            "message": "Metadata",
+            "translation": "Metadatos"
         },
         {
             "id": "Experimental Features",
@@ -728,6 +738,11 @@
             "id": "Use server SVCB records",
             "message": "Use server SVCB records",
             "translation": "Usar registros SVCB del servidor"
+        },
+        {
+            "id": "Clear All",
+            "message": "Clear All",
+            "translation": "Limpiar todo"
         },
         {
             "id": "Config already exists",
@@ -853,6 +868,11 @@
             "id": "Locations",
             "message": "Locations",
             "translation": "Ruta URL"
+        },
+        {
+            "id": "Request headers",
+            "message": "Request headers",
+            "translation": "Solicitar encabezados"
         },
         {
             "id": "Multiplexer",
@@ -1333,6 +1353,11 @@
             "id": "Copy Access Address",
             "message": "Copy Access Address",
             "translation": "Copiar dirección de acceso"
+        },
+        {
+            "id": "This feature only supports text in INI or TOML format.",
+            "message": "This feature only supports text in INI or TOML format.",
+            "translation": "Esta función solo admite texto en formato INI o TOML."
         },
         {
             "id": "Delete proxy \"{Name}\"",

--- a/i18n/locales/ja-JP/messages.gotext.json
+++ b/i18n/locales/ja-JP/messages.gotext.json
@@ -465,6 +465,11 @@
             "translation": "トークンのURL"
         },
         {
+            "id": "Parameters",
+            "message": "Parameters",
+            "translation": "パラメーター"
+        },
+        {
             "id": "Authentication",
             "message": "Authentication",
             "translation": "認証"
@@ -520,11 +525,6 @@
             "translation": "管理者アドレス"
         },
         {
-            "id": "Admin Port",
-            "message": "Admin Port",
-            "translation": "管理ポート"
-        },
-        {
             "id": "Password",
             "message": "Password",
             "translation": "パスワード"
@@ -538,6 +538,11 @@
             "id": "Select a local directory that the admin server will load resources from.",
             "message": "Select a local directory that the admin server will load resources from.",
             "translation": "管理サーバーがリソースをロードするローカルディレクトリを選択します。"
+        },
+        {
+            "id": "Other Options",
+            "message": "Other Options",
+            "translation": "別のオプション"
         },
         {
             "id": "Auto Delete",
@@ -588,6 +593,11 @@
             "id": "Pool Count",
             "message": "Pool Count",
             "translation": "接続プールの数"
+        },
+        {
+            "id": "UDP Packet Size",
+            "message": "UDP Packet Size",
+            "translation": "UDPパケットサイズ"
         },
         {
             "id": "Heartbeat",
@@ -675,6 +685,11 @@
             "translation": "信頼できる CA ファイルを選択します"
         },
         {
+            "id": "Disable custom first byte",
+            "message": "Disable custom first byte",
+            "translation": "カスタムの先頭バイトを無効にする"
+        },
+        {
             "id": "Advanced",
             "message": "Advanced",
             "translation": "高度"
@@ -695,11 +710,6 @@
             "translation": "送信元アドレス"
         },
         {
-            "id": "Other Options",
-            "message": "Other Options",
-            "translation": "別のオプション"
-        },
-        {
             "id": "Exit after login failure",
             "message": "Exit after login failure",
             "translation": "ログイン失敗後に終了"
@@ -710,9 +720,9 @@
             "translation": "起動時に自動起動を無効にする"
         },
         {
-            "id": "Custom",
-            "message": "Custom",
-            "translation": "カスタム"
+            "id": "Metadata",
+            "message": "Metadata",
+            "translation": "メタデータ"
         },
         {
             "id": "Experimental Features",
@@ -738,6 +748,11 @@
             "id": "Use server SVCB records",
             "message": "Use server SVCB records",
             "translation": "サーバーSVCBレコードを使用する"
+        },
+        {
+            "id": "Clear All",
+            "message": "Clear All",
+            "translation": "すべてクリア"
         },
         {
             "id": "Config already exists",
@@ -863,6 +878,11 @@
             "id": "Locations",
             "message": "Locations",
             "translation": "URL ルーティング"
+        },
+        {
+            "id": "Request headers",
+            "message": "Request headers",
+            "translation": "リクエストヘッダー"
         },
         {
             "id": "Multiplexer",
@@ -1343,6 +1363,11 @@
             "id": "Copy Access Address",
             "message": "Copy Access Address",
             "translation": "アクセスアドレスのコピー"
+        },
+        {
+            "id": "This feature only supports text in INI or TOML format.",
+            "message": "This feature only supports text in INI or TOML format.",
+            "translation": "この機能は、INI または TOML 形式のテキストのみをサポートします。"
         },
         {
             "id": "Delete proxy \"{Name}\"",

--- a/i18n/locales/ko-KR/messages.gotext.json
+++ b/i18n/locales/ko-KR/messages.gotext.json
@@ -455,6 +455,11 @@
             "translation": "토큰 URL"
         },
         {
+            "id": "Parameters",
+            "message": "Parameters",
+            "translation": "매개변수"
+        },
+        {
             "id": "Authentication",
             "message": "Authentication",
             "translation": "입증"
@@ -510,11 +515,6 @@
             "translation": "관리자 주소"
         },
         {
-            "id": "Admin Port",
-            "message": "Admin Port",
-            "translation": "관리 포트"
-        },
-        {
             "id": "Password",
             "message": "Password",
             "translation": "비밀번호"
@@ -528,6 +528,11 @@
             "id": "Select a local directory that the admin server will load resources from.",
             "message": "Select a local directory that the admin server will load resources from.",
             "translation": "관리 서버가 리소스를 로드할 로컬 디렉토리를 선택하십시오."
+        },
+        {
+            "id": "Other Options",
+            "message": "Other Options",
+            "translation": "다른 옵션"
         },
         {
             "id": "Auto Delete",
@@ -578,6 +583,11 @@
             "id": "Pool Count",
             "message": "Pool Count",
             "translation": "연결 수"
+        },
+        {
+            "id": "UDP Packet Size",
+            "message": "UDP Packet Size",
+            "translation": "UDP 패킷 크기"
         },
         {
             "id": "Heartbeat",
@@ -665,6 +675,11 @@
             "translation": "신뢰할 수 있는 CA 파일 선택"
         },
         {
+            "id": "Disable custom first byte",
+            "message": "Disable custom first byte",
+            "translation": "맞춤 첫 번째 바이트 비활성화"
+        },
+        {
             "id": "Advanced",
             "message": "Advanced",
             "translation": "고급의"
@@ -685,11 +700,6 @@
             "translation": "소스 주소"
         },
         {
-            "id": "Other Options",
-            "message": "Other Options",
-            "translation": "다른 옵션"
-        },
-        {
             "id": "Exit after login failure",
             "message": "Exit after login failure",
             "translation": "로그인 실패 후 종료"
@@ -700,9 +710,9 @@
             "translation": "부팅 시 자동 시작 비활성화"
         },
         {
-            "id": "Custom",
-            "message": "Custom",
-            "translation": "관습"
+            "id": "Metadata",
+            "message": "Metadata",
+            "translation": "메타데이터"
         },
         {
             "id": "Experimental Features",
@@ -728,6 +738,11 @@
             "id": "Use server SVCB records",
             "message": "Use server SVCB records",
             "translation": "서버 SVCB 기록 사용"
+        },
+        {
+            "id": "Clear All",
+            "message": "Clear All",
+            "translation": "모두 지우기"
         },
         {
             "id": "Config already exists",
@@ -853,6 +868,11 @@
             "id": "Locations",
             "message": "Locations",
             "translation": "URL 라우팅"
+        },
+        {
+            "id": "Request headers",
+            "message": "Request headers",
+            "translation": "요청 헤더"
         },
         {
             "id": "Multiplexer",
@@ -1333,6 +1353,11 @@
             "id": "Copy Access Address",
             "message": "Copy Access Address",
             "translation": "액세스 주소 복사"
+        },
+        {
+            "id": "This feature only supports text in INI or TOML format.",
+            "message": "This feature only supports text in INI or TOML format.",
+            "translation": "이 기능은 INI 또는 TOML 형식의 텍스트만 지원합니다."
         },
         {
             "id": "Delete proxy \"{Name}\"",

--- a/i18n/locales/zh-CN/messages.gotext.json
+++ b/i18n/locales/zh-CN/messages.gotext.json
@@ -455,6 +455,11 @@
             "translation": "令牌地址"
         },
         {
+            "id": "Parameters",
+            "message": "Parameters",
+            "translation": "参数"
+        },
+        {
             "id": "Authentication",
             "message": "Authentication",
             "translation": "鉴权"
@@ -510,11 +515,6 @@
             "translation": "管理地址"
         },
         {
-            "id": "Admin Port",
-            "message": "Admin Port",
-            "translation": "管理端口"
-        },
-        {
             "id": "Password",
             "message": "Password",
             "translation": "密码"
@@ -528,6 +528,11 @@
             "id": "Select a local directory that the admin server will load resources from.",
             "message": "Select a local directory that the admin server will load resources from.",
             "translation": "选择管理服务器使用的静态资源目录。"
+        },
+        {
+            "id": "Other Options",
+            "message": "Other Options",
+            "translation": "其他选项"
         },
         {
             "id": "Auto Delete",
@@ -578,6 +583,11 @@
             "id": "Pool Count",
             "message": "Pool Count",
             "translation": "连接池数量"
+        },
+        {
+            "id": "UDP Packet Size",
+            "message": "UDP Packet Size",
+            "translation": "UDP 包大小"
         },
         {
             "id": "Heartbeat",
@@ -665,6 +675,11 @@
             "translation": "选择受信任的证书"
         },
         {
+            "id": "Disable custom first byte",
+            "message": "Disable custom first byte",
+            "translation": "禁用自定义首字节"
+        },
+        {
             "id": "Advanced",
             "message": "Advanced",
             "translation": "高级"
@@ -685,11 +700,6 @@
             "translation": "使用源地址"
         },
         {
-            "id": "Other Options",
-            "message": "Other Options",
-            "translation": "其他选项"
-        },
-        {
             "id": "Exit after login failure",
             "message": "Exit after login failure",
             "translation": "初次登录失败后退出"
@@ -700,9 +710,9 @@
             "translation": "禁用开机自启动"
         },
         {
-            "id": "Custom",
-            "message": "Custom",
-            "translation": "自定义"
+            "id": "Metadata",
+            "message": "Metadata",
+            "translation": "元数据"
         },
         {
             "id": "Experimental Features",
@@ -728,6 +738,11 @@
             "id": "Use server SVCB records",
             "message": "Use server SVCB records",
             "translation": "使用服务器 SVCB 记录"
+        },
+        {
+            "id": "Clear All",
+            "message": "Clear All",
+            "translation": "全部清除"
         },
         {
             "id": "Config already exists",
@@ -853,6 +868,11 @@
             "id": "Locations",
             "message": "Locations",
             "translation": "URL 路由"
+        },
+        {
+            "id": "Request headers",
+            "message": "Request headers",
+            "translation": "请求头"
         },
         {
             "id": "Multiplexer",
@@ -1333,6 +1353,11 @@
             "id": "Copy Access Address",
             "message": "Copy Access Address",
             "translation": "复制访问地址"
+        },
+        {
+            "id": "This feature only supports text in INI or TOML format.",
+            "message": "This feature only supports text in INI or TOML format.",
+            "translation": "此功能仅支持 INI 或 TOML 格式的文本。"
         },
         {
             "id": "Delete proxy \"{Name}\"",

--- a/i18n/locales/zh-TW/messages.gotext.json
+++ b/i18n/locales/zh-TW/messages.gotext.json
@@ -455,6 +455,11 @@
             "translation": "令牌地址"
         },
         {
+            "id": "Parameters",
+            "message": "Parameters",
+            "translation": "參數"
+        },
+        {
             "id": "Authentication",
             "message": "Authentication",
             "translation": "鑑權"
@@ -510,11 +515,6 @@
             "translation": "管理地址"
         },
         {
-            "id": "Admin Port",
-            "message": "Admin Port",
-            "translation": "管理端口"
-        },
-        {
             "id": "Password",
             "message": "Password",
             "translation": "密碼"
@@ -528,6 +528,11 @@
             "id": "Select a local directory that the admin server will load resources from.",
             "message": "Select a local directory that the admin server will load resources from.",
             "translation": "選擇管理服務器使用的靜態資源目錄。"
+        },
+        {
+            "id": "Other Options",
+            "message": "Other Options",
+            "translation": "其他選項"
         },
         {
             "id": "Auto Delete",
@@ -578,6 +583,11 @@
             "id": "Pool Count",
             "message": "Pool Count",
             "translation": "連接池數量"
+        },
+        {
+            "id": "UDP Packet Size",
+            "message": "UDP Packet Size",
+            "translation": "UDP 包大小"
         },
         {
             "id": "Heartbeat",
@@ -665,6 +675,11 @@
             "translation": "選擇受信任的證書"
         },
         {
+            "id": "Disable custom first byte",
+            "message": "Disable custom first byte",
+            "translation": "停用自訂首字節"
+        },
+        {
             "id": "Advanced",
             "message": "Advanced",
             "translation": "高級"
@@ -685,11 +700,6 @@
             "translation": "使用源地址"
         },
         {
-            "id": "Other Options",
-            "message": "Other Options",
-            "translation": "其他選項"
-        },
-        {
             "id": "Exit after login failure",
             "message": "Exit after login failure",
             "translation": "初次登錄失敗後退出"
@@ -700,9 +710,9 @@
             "translation": "禁用開機自啟動"
         },
         {
-            "id": "Custom",
-            "message": "Custom",
-            "translation": "自定義"
+            "id": "Metadata",
+            "message": "Metadata",
+            "translation": "元數據"
         },
         {
             "id": "Experimental Features",
@@ -728,6 +738,11 @@
             "id": "Use server SVCB records",
             "message": "Use server SVCB records",
             "translation": "使用服務器 SVCB 記錄"
+        },
+        {
+            "id": "Clear All",
+            "message": "Clear All",
+            "translation": "全部清除"
         },
         {
             "id": "Config already exists",
@@ -853,6 +868,11 @@
             "id": "Locations",
             "message": "Locations",
             "translation": "URL 路由"
+        },
+        {
+            "id": "Request headers",
+            "message": "Request headers",
+            "translation": "請求頭"
         },
         {
             "id": "Multiplexer",
@@ -1333,6 +1353,11 @@
             "id": "Copy Access Address",
             "message": "Copy Access Address",
             "translation": "複製訪問地址"
+        },
+        {
+            "id": "This feature only supports text in INI or TOML format.",
+            "message": "This feature only supports text in INI or TOML format.",
+            "translation": "此功能僅支援 INI 或 TOML 格式的文字。"
         },
         {
             "id": "Delete proxy \"{Name}\"",

--- a/installer/actions/actions/CustomAction.cs
+++ b/installer/actions/actions/CustomAction.cs
@@ -246,6 +246,17 @@ namespace actions
                     session.Log(e.Message);
                 }
             }
+            foreach (string profile in Directory.GetFiles(profilePath, "*.ini"))
+            {
+                try
+                {
+                    File.Move(profile, Path.Combine(profilePath, Path.GetFileNameWithoutExtension(profile) + ".conf"));
+                }
+                catch (Exception e)
+                {
+                    session.Log(e.Message);
+                }
+            }
             return ActionResult.Success;
         }
 

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -417,6 +417,8 @@ func (conf *ClientConfig) Complete(read bool) {
 		conf.AdminUser = ""
 		conf.AdminPwd = ""
 		conf.AssetsDir = ""
+		conf.AdminTLS = v1.TLSConfig{}
+		conf.PprofEnable = false
 	}
 	conf.AutoDelete = conf.AutoDelete.Complete()
 	if !conf.TCPMux {

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -3,8 +3,11 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/fatedier/frp/pkg/config"
+	"github.com/fatedier/frp/pkg/config/v1"
 	frputil "github.com/fatedier/frp/pkg/util/util"
 	"github.com/thoas/go-funk"
 	"gopkg.in/ini.v1"
@@ -13,16 +16,32 @@ import (
 	"github.com/koho/frpmgr/pkg/util"
 )
 
+type ClientConfigV1 struct {
+	v1.ClientCommonConfig
+
+	Proxies  []v1.TypedProxyConfig   `json:"proxies,omitempty"`
+	Visitors []v1.TypedVisitorConfig `json:"visitors,omitempty"`
+
+	Internal Internal `json:"frpmgr,omitempty"`
+}
+
+type Internal struct {
+	ManualStart bool       `json:"manualStart,omitempty"`
+	SVCBEnable  bool       `json:"svcbEnable,omitempty"`
+	AutoDelete  AutoDelete `json:"autoDelete,omitempty"`
+}
+
 type ClientAuth struct {
-	AuthMethod               string `ini:"authentication_method,omitempty"`
-	AuthenticateHeartBeats   bool   `ini:"authenticate_heartbeats,omitempty" token:"true" oidc:"true"`
-	AuthenticateNewWorkConns bool   `ini:"authenticate_new_work_conns,omitempty" token:"true" oidc:"true"`
-	Token                    string `ini:"token,omitempty" token:"true"`
-	OIDCClientId             string `ini:"oidc_client_id,omitempty" oidc:"true"`
-	OIDCClientSecret         string `ini:"oidc_client_secret,omitempty" oidc:"true"`
-	OIDCAudience             string `ini:"oidc_audience,omitempty" oidc:"true"`
-	OIDCScope                string `ini:"oidc_scope,omitempty" oidc:"true"`
-	OIDCTokenEndpoint        string `ini:"oidc_token_endpoint_url,omitempty" oidc:"true"`
+	AuthMethod                   string            `ini:"authentication_method,omitempty"`
+	AuthenticateHeartBeats       bool              `ini:"authenticate_heartbeats,omitempty" token:"true" oidc:"true"`
+	AuthenticateNewWorkConns     bool              `ini:"authenticate_new_work_conns,omitempty" token:"true" oidc:"true"`
+	Token                        string            `ini:"token,omitempty" token:"true"`
+	OIDCClientId                 string            `ini:"oidc_client_id,omitempty" oidc:"true"`
+	OIDCClientSecret             string            `ini:"oidc_client_secret,omitempty" oidc:"true"`
+	OIDCAudience                 string            `ini:"oidc_audience,omitempty" oidc:"true"`
+	OIDCScope                    string            `ini:"oidc_scope,omitempty" oidc:"true"`
+	OIDCTokenEndpoint            string            `ini:"oidc_token_endpoint_url,omitempty" oidc:"true"`
+	OIDCAdditionalEndpointParams map[string]string `ini:"-" oidc:"true"`
 }
 
 func (ca ClientAuth) Complete() ClientAuth {
@@ -43,41 +62,45 @@ func (ca ClientAuth) Complete() ClientAuth {
 }
 
 type ClientCommon struct {
-	ClientAuth              `ini:",extends"`
-	ServerAddress           string   `ini:"server_addr,omitempty"`
-	ServerPort              string   `ini:"server_port,omitempty"`
-	NatHoleSTUNServer       string   `ini:"nat_hole_stun_server,omitempty"`
-	DialServerTimeout       int64    `ini:"dial_server_timeout,omitempty"`
-	DialServerKeepAlive     int64    `ini:"dial_server_keepalive,omitempty"`
-	ConnectServerLocalIP    string   `ini:"connect_server_local_ip,omitempty"`
-	HTTPProxy               string   `ini:"http_proxy,omitempty"`
-	LogFile                 string   `ini:"log_file,omitempty"`
-	LogLevel                string   `ini:"log_level,omitempty"`
-	LogMaxDays              uint     `ini:"log_max_days,omitempty"`
-	AdminAddr               string   `ini:"admin_addr,omitempty"`
-	AdminPort               string   `ini:"admin_port,omitempty"`
-	AdminUser               string   `ini:"admin_user,omitempty"`
-	AdminPwd                string   `ini:"admin_pwd,omitempty"`
-	AssetsDir               string   `ini:"assets_dir,omitempty"`
-	PoolCount               uint     `ini:"pool_count,omitempty"`
-	DNSServer               string   `ini:"dns_server,omitempty"`
-	Protocol                string   `ini:"protocol,omitempty"`
-	QUICKeepalivePeriod     int      `ini:"quic_keepalive_period,omitempty"`
-	QUICMaxIdleTimeout      int      `ini:"quic_max_idle_timeout,omitempty"`
-	QUICMaxIncomingStreams  int      `ini:"quic_max_incoming_streams,omitempty"`
-	LoginFailExit           bool     `ini:"login_fail_exit"`
-	User                    string   `ini:"user,omitempty"`
-	HeartbeatInterval       int64    `ini:"heartbeat_interval,omitempty"`
-	HeartbeatTimeout        int64    `ini:"heartbeat_timeout,omitempty"`
-	TCPMux                  bool     `ini:"tcp_mux"`
-	TCPMuxKeepaliveInterval int64    `ini:"tcp_mux_keepalive_interval,omitempty"`
-	TLSEnable               bool     `ini:"tls_enable"`
-	TLSCertFile             string   `ini:"tls_cert_file,omitempty"`
-	TLSKeyFile              string   `ini:"tls_key_file,omitempty"`
-	TLSTrustedCaFile        string   `ini:"tls_trusted_ca_file,omitempty"`
-	TLSServerName           string   `ini:"tls_server_name,omitempty"`
-	UDPPacketSize           int64    `ini:"udp_packet_size,omitempty"`
-	Start                   []string `ini:"start,omitempty"`
+	v1.APIMetadata            `ini:"-"`
+	ClientAuth                `ini:",extends"`
+	ServerAddress             string       `ini:"server_addr,omitempty"`
+	ServerPort                string       `ini:"server_port,omitempty"`
+	NatHoleSTUNServer         string       `ini:"nat_hole_stun_server,omitempty"`
+	DialServerTimeout         int64        `ini:"dial_server_timeout,omitempty"`
+	DialServerKeepAlive       int64        `ini:"dial_server_keepalive,omitempty"`
+	ConnectServerLocalIP      string       `ini:"connect_server_local_ip,omitempty"`
+	HTTPProxy                 string       `ini:"http_proxy,omitempty"`
+	LogFile                   string       `ini:"log_file,omitempty"`
+	LogLevel                  string       `ini:"log_level,omitempty"`
+	LogMaxDays                uint         `ini:"log_max_days,omitempty"`
+	AdminAddr                 string       `ini:"admin_addr,omitempty"`
+	AdminPort                 string       `ini:"admin_port,omitempty"`
+	AdminUser                 string       `ini:"admin_user,omitempty"`
+	AdminPwd                  string       `ini:"admin_pwd,omitempty"`
+	AdminTLS                  v1.TLSConfig `ini:"-"`
+	AssetsDir                 string       `ini:"assets_dir,omitempty"`
+	PoolCount                 uint         `ini:"pool_count,omitempty"`
+	DNSServer                 string       `ini:"dns_server,omitempty"`
+	Protocol                  string       `ini:"protocol,omitempty"`
+	QUICKeepalivePeriod       int          `ini:"quic_keepalive_period,omitempty"`
+	QUICMaxIdleTimeout        int          `ini:"quic_max_idle_timeout,omitempty"`
+	QUICMaxIncomingStreams    int          `ini:"quic_max_incoming_streams,omitempty"`
+	LoginFailExit             bool         `ini:"login_fail_exit"`
+	User                      string       `ini:"user,omitempty"`
+	HeartbeatInterval         int64        `ini:"heartbeat_interval,omitempty"`
+	HeartbeatTimeout          int64        `ini:"heartbeat_timeout,omitempty"`
+	TCPMux                    bool         `ini:"tcp_mux"`
+	TCPMuxKeepaliveInterval   int64        `ini:"tcp_mux_keepalive_interval,omitempty"`
+	TLSEnable                 bool         `ini:"tls_enable"`
+	TLSCertFile               string       `ini:"tls_cert_file,omitempty"`
+	TLSKeyFile                string       `ini:"tls_key_file,omitempty"`
+	TLSTrustedCaFile          string       `ini:"tls_trusted_ca_file,omitempty"`
+	TLSServerName             string       `ini:"tls_server_name,omitempty"`
+	UDPPacketSize             int64        `ini:"udp_packet_size,omitempty"`
+	Start                     []string     `ini:"start,omitempty"`
+	PprofEnable               bool         `ini:"pprof_enable,omitempty"`
+	DisableCustomTLSFirstByte bool         `ini:"disable_custom_tls_first_byte"`
 
 	// ManualStart defines whether to start the config on system boot.
 	ManualStart bool `ini:"frpmgr_manual_start,omitempty"`
@@ -91,8 +114,8 @@ type ClientCommon struct {
 	// AutoDelete is a mechanism for temporary use.
 	// The config will be stopped and deleted at some point.
 	AutoDelete `ini:",extends"`
-	// Custom collects all the unparsed options.
-	Custom map[string]string `ini:"-"`
+	// Client meta info
+	Metas map[string]string `ini:"-"`
 }
 
 // BaseProxyConf provides configuration info that is common to all types.
@@ -144,24 +167,25 @@ type BaseProxyConf struct {
 	HealthCheckType string `ini:"health_check_type,omitempty"` // tcp | http
 	// Health checking parameters.
 	HealthCheckConf `ini:",extends"`
-	// Custom collects all the unparsed options.
-	Custom map[string]string `ini:"-"`
+	// Meta info for each proxy
+	Metas map[string]string `ini:"-"`
 	// Disabled defines whether to start the proxy.
 	Disabled bool `ini:"-"`
 }
 
 type PluginParams struct {
-	PluginLocalAddr         string `ini:"plugin_local_addr,omitempty" http2https:"true" https2https:"true" https2http:"true"`
-	PluginCrtPath           string `ini:"plugin_crt_path,omitempty" https2https:"true" https2http:"true"`
-	PluginKeyPath           string `ini:"plugin_key_path,omitempty" https2https:"true" https2http:"true"`
-	PluginHostHeaderRewrite string `ini:"plugin_host_header_rewrite,omitempty" http2https:"true" https2https:"true" https2http:"true"`
-	PluginHttpUser          string `ini:"plugin_http_user,omitempty" http_proxy:"true" static_file:"true"`
-	PluginHttpPasswd        string `ini:"plugin_http_passwd,omitempty" http_proxy:"true" static_file:"true"`
-	PluginUser              string `ini:"plugin_user,omitempty" socks5:"true"`
-	PluginPasswd            string `ini:"plugin_passwd,omitempty" socks5:"true"`
-	PluginLocalPath         string `ini:"plugin_local_path,omitempty" static_file:"true"`
-	PluginStripPrefix       string `ini:"plugin_strip_prefix,omitempty" static_file:"true"`
-	PluginUnixPath          string `ini:"plugin_unix_path,omitempty" unix_domain_socket:"true"`
+	PluginLocalAddr         string            `ini:"plugin_local_addr,omitempty" http2https:"true" https2https:"true" https2http:"true"`
+	PluginCrtPath           string            `ini:"plugin_crt_path,omitempty" https2https:"true" https2http:"true"`
+	PluginKeyPath           string            `ini:"plugin_key_path,omitempty" https2https:"true" https2http:"true"`
+	PluginHostHeaderRewrite string            `ini:"plugin_host_header_rewrite,omitempty" http2https:"true" https2https:"true" https2http:"true"`
+	PluginHttpUser          string            `ini:"plugin_http_user,omitempty" http_proxy:"true" static_file:"true"`
+	PluginHttpPasswd        string            `ini:"plugin_http_passwd,omitempty" http_proxy:"true" static_file:"true"`
+	PluginUser              string            `ini:"plugin_user,omitempty" socks5:"true"`
+	PluginPasswd            string            `ini:"plugin_passwd,omitempty" socks5:"true"`
+	PluginLocalPath         string            `ini:"plugin_local_path,omitempty" static_file:"true"`
+	PluginStripPrefix       string            `ini:"plugin_strip_prefix,omitempty" static_file:"true"`
+	PluginUnixPath          string            `ini:"plugin_unix_path,omitempty" unix_domain_socket:"true"`
+	PluginHeaders           map[string]string `ini:"-" http2https:"true" https2https:"true" https2http:"true"`
 }
 
 // HealthCheckConf configures health checking. This can be useful for load
@@ -184,22 +208,23 @@ type HealthCheckConf struct {
 
 type Proxy struct {
 	BaseProxyConf     `ini:",extends"`
-	RemotePort        string `ini:"remote_port,omitempty" tcp:"true" udp:"true"`
-	Role              string `ini:"role,omitempty" stcp:"true" xtcp:"true" sudp:"true" visitor:"*"`
-	SK                string `ini:"sk,omitempty" stcp:"true" xtcp:"true" sudp:"true" visitor:"*"`
-	AllowUsers        string `ini:"allow_users,omitempty" stcp:"true" xtcp:"true" sudp:"true"`
-	ServerUser        string `ini:"server_user,omitempty" visitor:"*"`
-	ServerName        string `ini:"server_name,omitempty" visitor:"*"`
-	BindAddr          string `ini:"bind_addr,omitempty" visitor:"*"`
-	BindPort          string `ini:"bind_port,omitempty" visitor:"*"`
-	CustomDomains     string `ini:"custom_domains,omitempty" http:"true" https:"true" tcpmux:"true"`
-	SubDomain         string `ini:"subdomain,omitempty" http:"true" https:"true" tcpmux:"true"`
-	Locations         string `ini:"locations,omitempty" http:"true"`
-	HTTPUser          string `ini:"http_user,omitempty" http:"true" tcpmux:"true"`
-	HTTPPwd           string `ini:"http_pwd,omitempty" http:"true" tcpmux:"true"`
-	HostHeaderRewrite string `ini:"host_header_rewrite,omitempty" http:"true"`
-	Multiplexer       string `ini:"multiplexer,omitempty" tcpmux:"true"`
-	RouteByHTTPUser   string `ini:"route_by_http_user,omitempty" http:"true" tcpmux:"true"`
+	RemotePort        string            `ini:"remote_port,omitempty" tcp:"true" udp:"true"`
+	Role              string            `ini:"role,omitempty" stcp:"true" xtcp:"true" sudp:"true" visitor:"*"`
+	SK                string            `ini:"sk,omitempty" stcp:"true" xtcp:"true" sudp:"true" visitor:"*"`
+	AllowUsers        string            `ini:"allow_users,omitempty" stcp:"true" xtcp:"true" sudp:"true"`
+	ServerUser        string            `ini:"server_user,omitempty" visitor:"*"`
+	ServerName        string            `ini:"server_name,omitempty" visitor:"*"`
+	BindAddr          string            `ini:"bind_addr,omitempty" visitor:"*"`
+	BindPort          string            `ini:"bind_port,omitempty" visitor:"*"`
+	CustomDomains     string            `ini:"custom_domains,omitempty" http:"true" https:"true" tcpmux:"true"`
+	SubDomain         string            `ini:"subdomain,omitempty" http:"true" https:"true" tcpmux:"true"`
+	Locations         string            `ini:"locations,omitempty" http:"true"`
+	HTTPUser          string            `ini:"http_user,omitempty" http:"true" tcpmux:"true"`
+	HTTPPwd           string            `ini:"http_pwd,omitempty" http:"true" tcpmux:"true"`
+	HostHeaderRewrite string            `ini:"host_header_rewrite,omitempty" http:"true"`
+	Headers           map[string]string `ini:"-" http:"true"`
+	Multiplexer       string            `ini:"multiplexer,omitempty" tcpmux:"true"`
+	RouteByHTTPUser   string            `ini:"route_by_http_user,omitempty" http:"true" tcpmux:"true"`
 	// "kcp" or "quic"
 	Protocol          string `ini:"protocol,omitempty" visitor:"xtcp"`
 	KeepTunnelOpen    bool   `ini:"keep_tunnel_open,omitempty" visitor:"xtcp"`
@@ -247,9 +272,6 @@ func (p *Proxy) Marshal() ([]byte, error) {
 	}
 	if err = tp.ReflectFrom(p); err != nil {
 		return nil, err
-	}
-	for k, v := range p.Custom {
-		tp.Key(k).SetValue(v)
 	}
 	proxyBuffer := bytes.NewBuffer(nil)
 	if _, err = cfg.WriteTo(proxyBuffer); err != nil {
@@ -361,8 +383,11 @@ func (conf *ClientConfig) Save(path string) error {
 	if err = common.ReflectFrom(&conf.ClientCommon); err != nil {
 		return err
 	}
-	for k, v := range conf.ClientCommon.Custom {
-		common.Key(k).SetValue(v)
+	for k, v := range conf.ClientCommon.Metas {
+		common.Key("meta_" + k).SetValue(v)
+	}
+	for k, v := range conf.OIDCAdditionalEndpointParams {
+		common.Key("oidc_additional_" + k).SetValue(v)
 	}
 	for _, proxy := range conf.Proxies {
 		p, err := cfg.NewSection(proxy.Name)
@@ -372,8 +397,14 @@ func (conf *ClientConfig) Save(path string) error {
 		if err = p.ReflectFrom(&proxy); err != nil {
 			return err
 		}
-		for k, v := range proxy.Custom {
-			p.Key(k).SetValue(v)
+		for k, v := range proxy.Metas {
+			p.Key("meta_" + k).SetValue(v)
+		}
+		for k, v := range proxy.Headers {
+			p.Key("header_" + k).SetValue(v)
+		}
+		for k, v := range proxy.PluginHeaders {
+			p.Key("plugin_header_" + k).SetValue(v)
 		}
 	}
 	return cfg.SaveTo(path)
@@ -461,12 +492,9 @@ func NewProxyFromIni(name string, section *ini.Section) (*Proxy, error) {
 	if err := section.MapTo(&proxy); err != nil {
 		return nil, err
 	}
-	proxy.Custom = make(map[string]string)
-	for _, key := range section.Keys() {
-		if util.GetFieldNameByTag(Proxy{}, "ini", key.Name()) == "" {
-			proxy.Custom[key.Name()] = key.String()
-		}
-	}
+	proxy.Metas = util.GetMapWithoutPrefix(section.KeysHash(), "meta_")
+	proxy.Headers = util.GetMapWithoutPrefix(section.KeysHash(), "header_")
+	proxy.PluginHeaders = util.GetMapWithoutPrefix(section.KeysHash(), "plugin_header_")
 	return proxy, nil
 }
 
@@ -519,13 +547,8 @@ func UnmarshalClientConfFromIni(source interface{}) (*ClientConfig, error) {
 	if err = common.MapTo(&conf.ClientCommon); err != nil {
 		return nil, err
 	}
-	// Load unparsed options
-	conf.ClientCommon.Custom = make(map[string]string)
-	for _, key := range common.Keys() {
-		if util.GetFieldNameByTag(ClientCommon{}, "ini", key.Name()) == "" {
-			conf.ClientCommon.Custom[key.Name()] = key.String()
-		}
-	}
+	conf.Metas = util.GetMapWithoutPrefix(common.KeysHash(), "meta_")
+	conf.OIDCAdditionalEndpointParams = util.GetMapWithoutPrefix(common.KeysHash(), "oidc_additional_")
 	// Load all proxies
 	for _, section := range cfg.Sections() {
 		name := section.Name()
@@ -542,15 +565,48 @@ func UnmarshalClientConfFromIni(source interface{}) (*ClientConfig, error) {
 	return conf, nil
 }
 
+func UnmarshalClientConf(source interface{}) (*ClientConfig, error) {
+	var cfg ClientConfigV1
+	var b []byte
+	var err error
+	if path, ok := source.(string); ok {
+		b, err = os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		b = source.([]byte)
+	}
+	if config.DetectLegacyINIFormat(b) {
+		return UnmarshalClientConfFromIni(source)
+	}
+	if err = config.LoadConfigure(b, &cfg, false); err != nil {
+		return nil, err
+	}
+	var r ClientConfig
+	r.ClientCommon = ClientCommonFromV1(cfg.ClientCommonConfig)
+	r.ManualStart = cfg.Internal.ManualStart
+	r.SVCBEnable = cfg.Internal.SVCBEnable
+	r.AutoDelete = cfg.Internal.AutoDelete
+	for _, v := range cfg.Proxies {
+		r.Proxies = append(r.Proxies, ClientProxyFromV1(v))
+	}
+	for _, v := range cfg.Visitors {
+		r.Proxies = append(r.Proxies, ClientVisitorFromV1(v))
+	}
+	return &r, nil
+}
+
 func NewDefaultClientConfig() *ClientConfig {
 	return &ClientConfig{
 		ClientCommon: ClientCommon{
-			ClientAuth: ClientAuth{AuthMethod: consts.AuthToken},
-			ServerPort: "7000",
-			LogLevel:   "info",
-			TCPMux:     true,
-			TLSEnable:  true,
-			AutoDelete: AutoDelete{DeleteMethod: consts.DeleteRelative},
+			ClientAuth:                ClientAuth{AuthMethod: consts.AuthToken},
+			ServerPort:                "7000",
+			LogLevel:                  "info",
+			TCPMux:                    true,
+			TLSEnable:                 true,
+			DisableCustomTLSFirstByte: true,
+			AutoDelete:                AutoDelete{DeleteMethod: consts.DeleteRelative},
 		},
 		Proxies: make([]*Proxy, 0),
 	}

--- a/pkg/config/client_test.go
+++ b/pkg/config/client_test.go
@@ -29,7 +29,7 @@ func TestUnmarshalClientConfFromIni(t *testing.T) {
 	expected.ServerPort = "7001"
 	expected.Token = "123456"
 	expected.ManualStart = true
-	expected.Custom = map[string]string{"meta_1": "value"}
+	expected.Metas = map[string]string{"1": "value"}
 	expected.DeleteMethod = "absolute"
 	expected.DeleteAfterDate = time.Date(2023, 3, 23, 0, 0, 0, 0, time.UTC)
 	expected.Proxies = append(expected.Proxies, &Proxy{
@@ -38,7 +38,7 @@ func TestUnmarshalClientConfFromIni(t *testing.T) {
 			Type:      "tcp",
 			LocalIP:   "192.168.1.1",
 			LocalPort: "22",
-			Custom:    map[string]string{"meta_2": "value"},
+			Metas:     map[string]string{"2": "value"},
 		},
 		RemotePort: "6000",
 	})

--- a/pkg/config/conf.go
+++ b/pkg/config/conf.go
@@ -47,11 +47,11 @@ type AutoDelete struct {
 	// DeleteMethod specifies what delete method to use to delete the config.
 	// If "absolute" is specified, the expiry date is set in config. If "relative" is specified, the expiry date
 	// is calculated by adding the days to the file modification time. If it's empty, the config has no expiry date.
-	DeleteMethod string `ini:"frpmgr_delete_method,omitempty"`
+	DeleteMethod string `ini:"frpmgr_delete_method,omitempty" json:"method,omitempty"`
 	// DeleteAfterDays is the number of days a config will be kept, after which it may be stopped and deleted.
-	DeleteAfterDays uint `ini:"frpmgr_delete_after_days,omitempty" relative:"true"`
+	DeleteAfterDays uint `ini:"frpmgr_delete_after_days,omitempty" relative:"true" json:"afterDays,omitempty"`
 	// DeleteAfterDate is the last date the config will be valid, after which it may be stopped and deleted.
-	DeleteAfterDate time.Time `ini:"frpmgr_delete_after_date,omitempty" absolute:"true"`
+	DeleteAfterDate time.Time `ini:"frpmgr_delete_after_date,omitempty" absolute:"true" json:"afterDate,omitempty"`
 }
 
 func (ad AutoDelete) Complete() AutoDelete {

--- a/pkg/config/conversion.go
+++ b/pkg/config/conversion.go
@@ -1,0 +1,216 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/fatedier/frp/pkg/config/v1"
+	"github.com/samber/lo"
+)
+
+func ClientCommonFromV1(c v1.ClientCommonConfig) (r ClientCommon) {
+	r.APIMetadata = c.APIMetadata
+
+	// Auth client config
+	r.AuthMethod = string(c.Auth.Method)
+	r.Token = c.Auth.Token
+	r.OIDCClientId = c.Auth.OIDC.ClientID
+	r.OIDCClientSecret = c.Auth.OIDC.ClientSecret
+	r.OIDCAudience = c.Auth.OIDC.Audience
+	r.OIDCScope = c.Auth.OIDC.Scope
+	r.OIDCTokenEndpoint = c.Auth.OIDC.TokenEndpointURL
+	r.OIDCAdditionalEndpointParams = c.Auth.OIDC.AdditionalEndpointParams
+	if lo.Contains(c.Auth.AdditionalScopes, v1.AuthScopeHeartBeats) {
+		r.AuthenticateHeartBeats = true
+	}
+	if lo.Contains(c.Auth.AdditionalScopes, v1.AuthScopeNewWorkConns) {
+		r.AuthenticateNewWorkConns = true
+	}
+
+	r.User = c.User
+	r.ServerAddress = c.ServerAddr
+	if c.ServerPort != 0 {
+		r.ServerPort = strconv.Itoa(c.ServerPort)
+	}
+	r.NatHoleSTUNServer = c.NatHoleSTUNServer
+	r.DNSServer = c.DNSServer
+	if c.LoginFailExit == nil || *c.LoginFailExit {
+		r.LoginFailExit = true
+	}
+	r.Start = c.Start
+
+	// Log
+	r.LogFile = c.Log.To
+	r.LogLevel = c.Log.Level
+	r.LogMaxDays = uint(c.Log.MaxDays)
+
+	// Admin
+	r.AdminAddr = c.WebServer.Addr
+	if c.WebServer.Port != 0 {
+		r.AdminPort = strconv.Itoa(c.WebServer.Port)
+	}
+	r.AdminUser = c.WebServer.User
+	r.AdminPwd = c.WebServer.Password
+	r.AssetsDir = c.WebServer.AssetsDir
+	r.PprofEnable = c.WebServer.PprofEnable
+	if c.WebServer.TLS != nil {
+		r.AdminTLS = *c.WebServer.TLS
+	}
+
+	// Transport
+	r.Protocol = c.Transport.Protocol
+	r.DialServerTimeout = c.Transport.DialServerTimeout
+	r.DialServerKeepAlive = c.Transport.DialServerKeepAlive
+	r.ConnectServerLocalIP = c.Transport.ConnectServerLocalIP
+	r.HTTPProxy = c.Transport.ProxyURL
+	r.PoolCount = uint(c.Transport.PoolCount)
+	if c.Transport.TCPMux == nil || *c.Transport.TCPMux {
+		r.TCPMux = true
+	}
+	r.TCPMuxKeepaliveInterval = c.Transport.TCPMuxKeepaliveInterval
+	r.QUICMaxIncomingStreams = c.Transport.QUIC.MaxIncomingStreams
+	r.QUICKeepalivePeriod = c.Transport.QUIC.KeepalivePeriod
+	r.QUICMaxIdleTimeout = c.Transport.QUIC.MaxIdleTimeout
+	r.HeartbeatInterval = c.Transport.HeartbeatInterval
+	r.HeartbeatTimeout = c.Transport.HeartbeatTimeout
+	if c.Transport.TLS.Enable == nil || *c.Transport.TLS.Enable {
+		r.TLSEnable = true
+	}
+	r.TLSCertFile = c.Transport.TLS.CertFile
+	r.TLSKeyFile = c.Transport.TLS.KeyFile
+	r.TLSTrustedCaFile = c.Transport.TLS.TrustedCaFile
+	r.TLSServerName = c.Transport.TLS.ServerName
+	if c.Transport.TLS.DisableCustomTLSFirstByte == nil || *c.Transport.TLS.DisableCustomTLSFirstByte {
+		r.DisableCustomTLSFirstByte = true
+	}
+	r.UDPPacketSize = c.UDPPacketSize
+	r.Metas = c.Metadatas
+	return
+}
+
+func ClientProxyFromV1(pxyCfg v1.TypedProxyConfig) *Proxy {
+	var r Proxy
+	clientProxyBaseFromV1(pxyCfg.GetBaseConfig(), &r)
+	switch v := pxyCfg.ProxyConfigurer.(type) {
+	case *v1.TCPProxyConfig:
+		r.RemotePort = strconv.Itoa(v.RemotePort)
+	case *v1.UDPProxyConfig:
+		r.RemotePort = strconv.Itoa(v.RemotePort)
+	case *v1.HTTPProxyConfig:
+		r.SubDomain = v.SubDomain
+		r.CustomDomains = strings.Join(v.CustomDomains, ",")
+		r.Locations = strings.Join(v.Locations, ",")
+		r.HTTPUser = v.HTTPUser
+		r.HTTPPwd = v.HTTPPassword
+		r.HostHeaderRewrite = v.HostHeaderRewrite
+		r.RouteByHTTPUser = v.RouteByHTTPUser
+		r.Headers = v.RequestHeaders.Set
+	case *v1.HTTPSProxyConfig:
+		r.SubDomain = v.SubDomain
+		r.CustomDomains = strings.Join(v.CustomDomains, ",")
+	case *v1.TCPMuxProxyConfig:
+		r.SubDomain = v.SubDomain
+		r.CustomDomains = strings.Join(v.CustomDomains, ",")
+		r.HTTPUser = v.HTTPUser
+		r.HTTPPwd = v.HTTPPassword
+		r.RouteByHTTPUser = v.RouteByHTTPUser
+		r.Multiplexer = v.Multiplexer
+	case *v1.STCPProxyConfig:
+		r.SK = v.Secretkey
+		r.AllowUsers = strings.Join(v.AllowUsers, ",")
+	case *v1.SUDPProxyConfig:
+		r.SK = v.Secretkey
+		r.AllowUsers = strings.Join(v.AllowUsers, ",")
+	case *v1.XTCPProxyConfig:
+		r.SK = v.Secretkey
+		r.AllowUsers = strings.Join(v.AllowUsers, ",")
+	}
+	return &r
+}
+
+func ClientVisitorFromV1(visitorCfg v1.TypedVisitorConfig) *Proxy {
+	var r Proxy
+	clientVisitorBaseFromV1(visitorCfg.GetBaseConfig(), &r)
+	switch v := visitorCfg.VisitorConfigurer.(type) {
+	case *v1.STCPVisitorConfig:
+	case *v1.SUDPVisitorConfig:
+	case *v1.XTCPVisitorConfig:
+		r.Protocol = v.Protocol
+		r.KeepTunnelOpen = v.KeepTunnelOpen
+		r.MaxRetriesAnHour = v.MaxRetriesAnHour
+		r.MinRetryInterval = v.MinRetryInterval
+		r.FallbackTo = v.FallbackTo
+		r.FallbackTimeoutMs = v.FallbackTimeoutMs
+	}
+	return &r
+}
+
+func clientProxyBaseFromV1(c *v1.ProxyBaseConfig, out *Proxy) {
+	out.Name = c.Name
+	out.Type = c.Type
+	out.UseEncryption = c.Transport.UseEncryption
+	out.UseCompression = c.Transport.UseCompression
+	out.BandwidthLimitMode = c.Transport.BandwidthLimitMode
+	out.BandwidthLimit = c.Transport.BandwidthLimit.String()
+	out.ProxyProtocolVersion = c.Transport.ProxyProtocolVersion
+	out.Group = c.LoadBalancer.Group
+	out.GroupKey = c.LoadBalancer.GroupKey
+	out.HealthCheckType = c.HealthCheck.Type
+	out.HealthCheckTimeoutS = c.HealthCheck.TimeoutSeconds
+	out.HealthCheckMaxFailed = c.HealthCheck.MaxFailed
+	out.HealthCheckIntervalS = c.HealthCheck.IntervalSeconds
+	out.HealthCheckURL = c.HealthCheck.Path
+	out.LocalIP = c.LocalIP
+	if c.LocalPort != 0 {
+		out.LocalPort = strconv.Itoa(c.LocalPort)
+	}
+
+	out.Metas = c.Metadatas
+	out.Plugin = c.Plugin.Type
+	switch v := c.Plugin.ClientPluginOptions.(type) {
+	case *v1.HTTP2HTTPSPluginOptions:
+		out.PluginLocalAddr = v.LocalAddr
+		out.PluginHostHeaderRewrite = v.HostHeaderRewrite
+		out.PluginHeaders = v.RequestHeaders.Set
+	case *v1.HTTPProxyPluginOptions:
+		out.PluginHttpUser = v.HTTPUser
+		out.PluginHttpPasswd = v.HTTPPassword
+	case *v1.HTTPS2HTTPPluginOptions:
+		out.PluginLocalAddr = v.LocalAddr
+		out.HostHeaderRewrite = v.HostHeaderRewrite
+		out.PluginCrtPath = v.CrtPath
+		out.PluginKeyPath = v.KeyPath
+		out.PluginHeaders = v.RequestHeaders.Set
+	case *v1.HTTPS2HTTPSPluginOptions:
+		out.PluginLocalAddr = v.LocalAddr
+		out.PluginHostHeaderRewrite = v.HostHeaderRewrite
+		out.PluginCrtPath = v.CrtPath
+		out.PluginKeyPath = v.KeyPath
+		out.PluginHeaders = v.RequestHeaders.Set
+	case *v1.Socks5PluginOptions:
+		out.PluginUser = v.Username
+		out.PluginPasswd = v.Password
+	case *v1.StaticFilePluginOptions:
+		out.PluginLocalPath = v.LocalPath
+		out.PluginStripPrefix = v.StripPrefix
+		out.PluginHttpUser = v.HTTPUser
+		out.PluginHttpPasswd = v.HTTPPassword
+	case *v1.UnixDomainSocketPluginOptions:
+		out.PluginUnixPath = v.UnixPath
+	}
+}
+
+func clientVisitorBaseFromV1(c *v1.VisitorBaseConfig, out *Proxy) {
+	out.Name = c.Name
+	out.Type = c.Type
+	out.Role = "visitor"
+	out.UseEncryption = c.Transport.UseEncryption
+	out.UseCompression = c.Transport.UseCompression
+	out.SK = c.SecretKey
+	out.ServerUser = c.ServerUser
+	out.ServerName = c.ServerName
+	out.BindAddr = c.BindAddr
+	if c.BindPort != 0 {
+		out.BindPort = strconv.Itoa(c.BindPort)
+	}
+}

--- a/pkg/consts/res.go
+++ b/pkg/consts/res.go
@@ -1,9 +1,13 @@
 package consts
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/lxn/walk"
 	. "github.com/lxn/walk/declarative"
 	"github.com/lxn/win"
+	"github.com/samber/lo"
 	"golang.org/x/sys/windows"
 
 	"github.com/koho/frpmgr/i18n"
@@ -88,10 +92,17 @@ var (
 	TextLarge   = Font{Family: defaultFontFamily, PointSize: 16}
 )
 
+var (
+	SupportedConfigFormats = []string{".ini", ".toml", ".json", ".yml", ".yaml"}
+	cfgPatterns            = lo.Map(append([]string{".zip"}, SupportedConfigFormats...), func(item string, index int) string {
+		return "*" + item
+	})
+)
+
 // Filters
 var (
 	FilterAllFiles = i18n.Sprintf("All Files") + " (*.*)|*.*"
-	FilterConfig   = i18n.Sprintf("Configuration Files") + " (*.zip, *.ini)|*.zip;*.ini|"
+	FilterConfig   = i18n.Sprintf("Configuration Files") + fmt.Sprintf(" (%s)|%s|", strings.Join(cfgPatterns, ", "), strings.Join(cfgPatterns, ";"))
 	FilterZip      = i18n.Sprintf("Configuration Files") + " (*.zip)|*.zip"
 	FilterCert     = i18n.Sprintf("Certificate Files") + " (*.crt, *.cer)|*.crt;*.cer|"
 	FilterKey      = i18n.Sprintf("Key Files") + " (*.key)|*.key|"

--- a/pkg/consts/res.go
+++ b/pkg/consts/res.go
@@ -51,7 +51,7 @@ const (
 	IconHttpFile     = 69
 	IconHttpProxy    = 114
 	IconOpenPort     = 135
-	IconVpn          = 47
+	IconLock         = 47
 	IconNewVersion1  = -1028
 	IconNewVersion2  = 1
 	IconUpdate       = -47

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -66,3 +66,19 @@ func prune(inValue reflect.Value, ret reflect.Value, value string, tag string) e
 	}
 	return nil
 }
+
+func GetMapWithoutPrefix(set map[string]string, prefix string) map[string]string {
+	m := make(map[string]string)
+
+	for key, value := range set {
+		if strings.HasPrefix(key, prefix) {
+			m[strings.TrimPrefix(key, prefix)] = value
+		}
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	return m
+}

--- a/ui/conf.go
+++ b/ui/conf.go
@@ -73,17 +73,18 @@ func (conf *Conf) Delete() (bool, error) {
 // Save config to the disk. The config will be completed before saving
 func (conf *Conf) Save() error {
 	conf.Data.Complete(false)
-	conf.Path = PathOfConf(conf.Name + ".ini")
+	conf.Path = PathOfConf(conf.Name + ".conf")
 	return conf.Data.Save(conf.Path)
 }
 
 var (
 	appConf = config.App{Defaults: config.ClientCommon{
-		ServerPort: "7000",
-		LogLevel:   "info",
-		LogMaxDays: 3,
-		TCPMux:     true,
-		TLSEnable:  true,
+		ServerPort:                "7000",
+		LogLevel:                  "info",
+		LogMaxDays:                3,
+		TCPMux:                    true,
+		TLSEnable:                 true,
+		DisableCustomTLSFirstByte: true,
 	}}
 	// The config list contains all the loaded configs
 	confList  []*Conf
@@ -94,14 +95,14 @@ var (
 func loadAllConfs() error {
 	_ = config.UnmarshalAppConfFromIni(config.DefaultAppFile, &appConf)
 	// Find all config files in `profiles` directory
-	files, err := filepath.Glob(PathOfConf("*.ini"))
+	files, err := filepath.Glob(PathOfConf("*.conf"))
 	if err != nil {
 		return err
 	}
 	confList = make([]*Conf, 0)
 	for _, f := range files {
 		c := NewConf(f, nil)
-		if conf, err := config.UnmarshalClientConfFromIni(f); err == nil {
+		if conf, err := config.UnmarshalClientConf(f); err == nil {
 			c.Data = conf
 			if conf.DeleteAfterDays > 0 {
 				if t, err := config.Expiry(f, conf.AutoDelete); err == nil && t <= 0 {

--- a/ui/editclient.go
+++ b/ui/editclient.go
@@ -61,7 +61,7 @@ func NewEditClientDialog(conf *Conf, name string) *EditClientDialog {
 	v.data = data
 	v.binder = &editClientBinder{
 		Name:         v.Conf.Name,
-		CustomText:   util.Map2String(data.Custom),
+		CustomText:   util.Map2String(data.Metas),
 		ClientCommon: v.data.ClientCommon,
 	}
 	if name != "" {
@@ -154,7 +154,14 @@ func (cd *EditClientDialog) authConfPage() TabPage {
 			Label{Visible: Bind("oidcCheck.Checked"), Text: i18n.SprintfColon("Scope")},
 			LineEdit{Visible: Bind("oidcCheck.Checked"), Text: Bind("OIDCScope")},
 			Label{Visible: Bind("oidcCheck.Checked"), Text: i18n.SprintfColon("Token Endpoint")},
-			LineEdit{Visible: Bind("oidcCheck.Checked"), Text: Bind("OIDCTokenEndpoint")},
+			Composite{
+				Visible: Bind("oidcCheck.Checked"),
+				Layout:  HBox{MarginsZero: true},
+				Children: []Widget{
+					LineEdit{Text: Bind("OIDCTokenEndpoint")},
+					ToolButton{Text: "#", ToolTipText: i18n.Sprintf("Parameters")},
+				},
+			},
 			Label{Visible: Bind("!noAuthCheck.Checked"), Text: i18n.SprintfColon("Authentication")},
 			Composite{
 				Visible: Bind("!noAuthCheck.Checked"),
@@ -196,9 +203,17 @@ func (cd *EditClientDialog) adminConfPage() TabPage {
 		Layout: Grid{Columns: 2},
 		Children: []Widget{
 			Label{Text: i18n.SprintfColon("Admin Address")},
-			LineEdit{Text: Bind("AdminAddr")},
-			Label{Text: i18n.SprintfColon("Admin Port")},
-			LineEdit{Name: "adminPort", Text: Bind("AdminPort", consts.ValidateInteger)},
+			Composite{
+				Layout: HBox{MarginsZero: true},
+				Children: []Widget{
+					LineEdit{Text: Bind("AdminAddr"), StretchFactor: 2},
+					Label{Text: ":"},
+					LineEdit{Name: "adminPort", Text: Bind("AdminPort", consts.ValidateInteger)},
+					ToolButton{Image: loadSysIcon("shell32", consts.IconVpn, 16), ToolTipText: "TLS", OnClicked: func() {
+						cd.adminTLSDialog().Run(cd.Form())
+					}},
+				},
+			},
 			Label{Enabled: Bind("adminPort.Text != ''"), Text: i18n.SprintfColon("User")},
 			LineEdit{Enabled: Bind("adminPort.Text != ''"), Text: Bind("AdminUser")},
 			Label{Enabled: Bind("adminPort.Text != ''"), Text: i18n.SprintfColon("Password")},
@@ -206,6 +221,8 @@ func (cd *EditClientDialog) adminConfPage() TabPage {
 			Label{Enabled: Bind("adminPort.Text != ''"), Text: i18n.SprintfColon("Assets")},
 			NewBrowseLineEdit(nil, true, Bind("adminPort.Text != ''"), Bind("AssetsDir"),
 				i18n.Sprintf("Select a local directory that the admin server will load resources from."), "", false),
+			Label{Enabled: Bind("adminPort.Text != ''"), Text: i18n.SprintfColon("Other Options")},
+			CheckBox{Enabled: Bind("adminPort.Text != ''"), Text: "Pprof", Checked: Bind("PprofEnable")},
 			Label{Text: i18n.SprintfColon("Auto Delete")},
 			NewRadioButtonGroup("DeleteMethod", nil, nil, []RadioButton{
 				{Name: "absCheck", Text: i18n.Sprintf("Absolute"), Value: consts.DeleteAbsolute},
@@ -239,7 +256,14 @@ func (cd *EditClientDialog) connectionConfPage() TabPage {
 			Label{Text: i18n.SprintfColon("HTTP Proxy")},
 			LineEdit{Text: Bind("HTTPProxy")},
 			Label{Text: i18n.SprintfColon("Pool Count")},
-			NumberEdit{Value: Bind("PoolCount")},
+			Composite{
+				Layout: HBox{MarginsZero: true},
+				Children: []Widget{
+					NumberEdit{Value: Bind("PoolCount")},
+					Label{Text: i18n.SprintfColon("UDP Packet Size")},
+					NumberEdit{Value: Bind("UDPPacketSize")},
+				},
+			},
 			Label{Text: i18n.SprintfColon("Heartbeat")},
 			Composite{
 				Layout: HBox{MarginsZero: true},
@@ -291,6 +315,8 @@ func (cd *EditClientDialog) tlsConfPage() TabPage {
 			Label{Visible: Bind("tlsCheck.Checked"), Text: i18n.SprintfColon("Trusted CA"), AlwaysConsumeSpace: true},
 			NewBrowseLineEdit(nil, Bind("tlsCheck.Checked"), true, Bind("TLSTrustedCaFile"),
 				i18n.Sprintf("Select Trusted CA File"), consts.FilterCert, true),
+			Label{Visible: Bind("tlsCheck.Checked"), Text: i18n.SprintfColon("Other Options")},
+			CheckBox{Visible: Bind("tlsCheck.Checked"), Text: i18n.Sprintf("Disable custom first byte"), Checked: Bind("DisableCustomTLSFirstByte")},
 		},
 	}
 }
@@ -328,7 +354,7 @@ func (cd *EditClientDialog) advancedConfPage() TabPage {
 						Layout: HBox{MarginsZero: true, Spacing: 18},
 						Children: []Widget{
 							LinkLabel{
-								Text: fmt.Sprintf("<a>%s</a>", i18n.SprintfEllipsis("Custom")),
+								Text: fmt.Sprintf("<a>%s</a>", i18n.SprintfEllipsis("Metadata")),
 								OnLinkActivated: func(link *walk.LinkLabelLink) {
 									cd.customConfDialog().Run(cd.Form())
 								},
@@ -366,6 +392,36 @@ func (cd *EditClientDialog) experimentDialog() Dialog {
 	expDialog.MinSize = Size{Width: 300, Height: 180}
 	expDialog.FixedSize = true
 	return expDialog
+}
+
+func (cd *EditClientDialog) adminTLSDialog() Dialog {
+	var widgets [4]*walk.LineEdit
+	customDialog := NewBasicDialog(nil, "TLS",
+		loadSysIcon("shell32", consts.IconVpn, 32),
+		DataBinder{DataSource: &cd.binder.AdminTLS}, nil,
+		Label{Text: i18n.SprintfColon("Host Name")},
+		LineEdit{AssignTo: &widgets[0], Text: Bind("ServerName")},
+		Label{Text: i18n.SprintfColon("Certificate")},
+		NewBrowseLineEdit(&widgets[1], true, true, Bind("CertFile"),
+			i18n.Sprintf("Select Certificate File"), consts.FilterCert, true),
+		Label{Text: i18n.SprintfColon("Certificate Key")},
+		NewBrowseLineEdit(&widgets[2], true, true, Bind("KeyFile"),
+			i18n.Sprintf("Select Certificate Key File"), consts.FilterKey, true),
+		Label{Text: i18n.SprintfColon("Trusted CA")},
+		NewBrowseLineEdit(&widgets[3], true, true, Bind("TrustedCaFile"),
+			i18n.Sprintf("Select Trusted CA File"), consts.FilterCert, true),
+		VSpacer{Size: 4},
+	)
+	customDialog.MinSize = Size{Width: 350}
+	customDialog.FixedSize = true
+	buttons := customDialog.Children[len(customDialog.Children)-1].(Composite)
+	buttons.Children = append([]Widget{PushButton{Text: i18n.Sprintf("Clear All"), OnClicked: func() {
+		for _, widget := range widgets {
+			widget.SetText("")
+		}
+	}}}, buttons.Children...)
+	customDialog.Children[len(customDialog.Children)-1] = buttons
+	return customDialog
 }
 
 func (cd *EditClientDialog) shutdownService(wait bool) error {
@@ -439,7 +495,7 @@ func (cd *EditClientDialog) onSave() {
 	cd.Conf.Name = newConf.Name
 	// The order matters
 	cd.data.ClientCommon = newConf.ClientCommon
-	cd.data.Custom = util.String2Map(newConf.CustomText)
+	cd.data.Metas = util.String2Map(newConf.CustomText)
 	cd.Accept()
 }
 

--- a/ui/editclient.go
+++ b/ui/editclient.go
@@ -209,9 +209,13 @@ func (cd *EditClientDialog) adminConfPage() TabPage {
 					LineEdit{Text: Bind("AdminAddr"), StretchFactor: 2},
 					Label{Text: ":"},
 					LineEdit{Name: "adminPort", Text: Bind("AdminPort", consts.ValidateInteger)},
-					ToolButton{Image: loadSysIcon("shell32", consts.IconVpn, 16), ToolTipText: "TLS", OnClicked: func() {
-						cd.adminTLSDialog().Run(cd.Form())
-					}},
+					ToolButton{
+						Enabled:     Bind("adminPort.Text != ''"),
+						Image:       loadSysIcon("shell32", consts.IconLock, 16),
+						ToolTipText: "TLS", OnClicked: func() {
+							cd.adminTLSDialog().Run(cd.Form())
+						},
+					},
 				},
 			},
 			Label{Enabled: Bind("adminPort.Text != ''"), Text: i18n.SprintfColon("User")},
@@ -397,7 +401,7 @@ func (cd *EditClientDialog) experimentDialog() Dialog {
 func (cd *EditClientDialog) adminTLSDialog() Dialog {
 	var widgets [4]*walk.LineEdit
 	customDialog := NewBasicDialog(nil, "TLS",
-		loadSysIcon("shell32", consts.IconVpn, 32),
+		loadSysIcon("shell32", consts.IconLock, 32),
 		DataBinder{DataSource: &cd.binder.AdminTLS}, nil,
 		Label{Text: i18n.SprintfColon("Host Name")},
 		LineEdit{AssignTo: &widgets[0], Text: Bind("ServerName")},

--- a/ui/editproxy.go
+++ b/ui/editproxy.go
@@ -205,7 +205,14 @@ func (pd *EditProxyDialog) basicProxyPage() TabPage {
 			Label{Visible: Bind("vm.DomainVisible"), Text: i18n.SprintfColon("Custom Domains")},
 			LineEdit{Visible: Bind("vm.DomainVisible"), Text: Bind("CustomDomains")},
 			Label{Visible: Bind("vm.HTTPVisible"), Text: i18n.SprintfColon("Locations")},
-			LineEdit{Visible: Bind("vm.HTTPVisible"), Text: Bind("Locations")},
+			Composite{
+				Visible: Bind("vm.HTTPVisible"),
+				Layout:  HBox{MarginsZero: true},
+				Children: []Widget{
+					LineEdit{Text: Bind("Locations")},
+					ToolButton{Text: "H", ToolTipText: i18n.Sprintf("Request headers")},
+				},
+			},
 			Label{Visible: Bind("vm.MuxVisible"), Text: i18n.SprintfColon("Multiplexer")},
 			ComboBox{
 				Visible: Bind("vm.MuxVisible"),
@@ -324,7 +331,14 @@ func (pd *EditProxyDialog) pluginProxyPage() TabPage {
 			Label{Visible: Bind("vm.PluginAuthVisible"), Text: i18n.SprintfColon("Password")},
 			LineEdit{Visible: Bind("vm.PluginAuthVisible"), Text: Bind("PluginPasswd"), PasswordMode: true},
 			Label{Visible: Bind("vm.PluginHTTPFwdVisible"), Text: i18n.SprintfColon("Local Address")},
-			LineEdit{Visible: Bind("vm.PluginHTTPFwdVisible"), Text: Bind("PluginLocalAddr")},
+			Composite{
+				Visible: Bind("vm.PluginHTTPFwdVisible"),
+				Layout:  HBox{MarginsZero: true},
+				Children: []Widget{
+					LineEdit{Text: Bind("PluginLocalAddr")},
+					ToolButton{Text: "H", ToolTipText: i18n.Sprintf("Request headers")},
+				},
+			},
 			Label{Visible: Bind("vm.PluginCertVisible"), Text: i18n.SprintfColon("Certificate")},
 			NewBrowseLineEdit(nil, Bind("vm.PluginCertVisible"), true, Bind("PluginCrtPath"),
 				i18n.Sprintf("Select Certificate File"), consts.FilterCert, true),
@@ -375,11 +389,11 @@ func (pd *EditProxyDialog) healthCheckProxyPage() TabPage {
 
 func (pd *EditProxyDialog) customProxyPage() TabPage {
 	return TabPage{
-		Title:  i18n.Sprintf("Custom"),
+		Title:  i18n.Sprintf("Metadata"),
 		Layout: VBox{},
 		Children: []Widget{
 			Label{Text: i18n.Sprintf("* Refer to the parameters supported by FRP.")},
-			TextEdit{AssignTo: &pd.customText, Text: util.Map2String(pd.binder.Custom), VScroll: true},
+			TextEdit{AssignTo: &pd.customText, Text: util.Map2String(pd.binder.Metas), VScroll: true},
 		},
 	}
 }
@@ -411,7 +425,7 @@ func (pd *EditProxyDialog) onSave() {
 		return
 	}
 	// Update custom options
-	pd.binder.Proxy.Custom = util.String2Map(pd.customText.Text())
+	pd.binder.Proxy.Metas = util.String2Map(pd.customText.Text())
 	// Update role
 	if pd.binder.Visitor {
 		pd.binder.Proxy.Role = "visitor"

--- a/ui/proxyview.go
+++ b/ui/proxyview.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	frpconfig "github.com/fatedier/frp/pkg/config"
+	v1 "github.com/fatedier/frp/pkg/config/v1"
 	"github.com/lxn/walk"
 	. "github.com/lxn/walk/declarative"
 
@@ -372,9 +374,31 @@ func (pv *ProxyView) onClipboardImport() {
 	if err != nil || strings.TrimSpace(text) == "" {
 		return
 	}
-	proxy, err := config.UnmarshalProxyFromIni([]byte(text))
+	var proxy *config.Proxy
+	if strings.HasPrefix(text, "[[proxies]]") {
+		var proxies struct {
+			C []v1.TypedProxyConfig `json:"proxies"`
+		}
+		if err = frpconfig.LoadConfigure([]byte(text), &proxies, false); err == nil && len(proxies.C) > 0 {
+			proxy = config.ClientProxyFromV1(proxies.C[0])
+		}
+	} else if strings.HasPrefix(text, "[[visitors]]") {
+		var visitors struct {
+			C []v1.TypedVisitorConfig `json:"visitors"`
+		}
+		if err = frpconfig.LoadConfigure([]byte(text), &visitors, false); err == nil && len(visitors.C) > 0 {
+			proxy = config.ClientVisitorFromV1(visitors.C[0])
+		}
+	} else if strings.HasPrefix(text, "[") {
+		proxy, err = config.UnmarshalProxyFromIni([]byte(text))
+	} else {
+		err = fmt.Errorf(i18n.Sprintf("This feature only supports text in INI or TOML format."))
+	}
 	if err != nil {
 		showError(err, pv.Form())
+		return
+	}
+	if proxy == nil {
 		return
 	}
 	pv.onEdit(false, proxy)

--- a/ui/proxyview.go
+++ b/ui/proxyview.go
@@ -170,9 +170,9 @@ func (pv *ProxyView) createToolbar() ToolBar {
 					Action{
 						AssignTo: &pv.vpnAction,
 						Text:     "OpenVPN",
-						Image:    loadSysIcon("shell32", consts.IconVpn, 16),
+						Image:    loadSysIcon("shell32", consts.IconLock, 16),
 						OnTriggered: func() {
-							pv.onQuickAdd(NewSimpleProxyDialog("OpenVPN", loadSysIcon("shell32", consts.IconVpn, 32),
+							pv.onQuickAdd(NewSimpleProxyDialog("OpenVPN", loadSysIcon("shell32", consts.IconLock, 32),
 								"openvpn", []string{consts.ProxyTypeTCP, consts.ProxyTypeUDP}, ":1194"))
 						},
 					},

--- a/ui/proxyview.go
+++ b/ui/proxyview.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	frpconfig "github.com/fatedier/frp/pkg/config"
-	v1 "github.com/fatedier/frp/pkg/config/v1"
+	"github.com/fatedier/frp/pkg/config/v1"
 	"github.com/lxn/walk"
 	. "github.com/lxn/walk/declarative"
 


### PR DESCRIPTION
This PR introduces the following notable changes:

* We now support importing TOML, YAML, and JSON configurations.
* Configuration file extension changed from `.ini` to `.conf`.
* The Custom Options tab has been replaced with the Metadata tab.
* Added TLS (WIP) and Pprof config for admin server.
* Added endpoint parameter config for OIDC (missing GUI, WIP).
* Added request header config for HTTP proxy and plugin (missing GUI, WIP).
* The clipboard import feature in proxy table only supports text in INI or TOML format.

Please note that we still use the INI format to save the configuration. We will add a new TOML format and make both formats switchable in a single configuration.

Close #107.